### PR TITLE
Fluenter Gradle DSL

### DIFF
--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/BootstrapPlugin.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/BootstrapPlugin.java
@@ -49,10 +49,10 @@ import org.gradle.api.Project;
  *     }
  *
  *     spine {
- *         java {
+ *         enableJava {
  *             grpc = true
  *         }
- *         javaScript()
+ *         enableJavaScript()
  *     }
  *     }
  * </pre>

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
@@ -35,11 +35,12 @@ import static org.gradle.util.ConfigureUtil.configure;
 /**
  * The {@code spine} Gradle DSL extension.
  *
- * <p>Configures the project as a {@linkplain #java() Java} or/and a {@linkplain #javaScript()
+ * <p>Configures the project as a {@linkplain #enableJava() Java} or/and a {@linkplain #enableJavaScript()
  * JavaScript} project based on Spine.
  */
 public final class Extension {
 
+    @SuppressWarnings("DuplicateStringLiteralInspection") // Used in tests and with other meanings.
     static final String NAME = "spine";
 
     private final JavaExtension java;
@@ -55,11 +56,11 @@ public final class Extension {
      *
      * @param configuration
      *         Groovy style configuration
-     * @see #java()
+     * @see #enableJava()
      */
-    public void java(Closure configuration) {
+    public void enableJava(Closure configuration) {
         checkNotNull(configuration);
-        java();
+        enableJava();
         configure(configuration, java);
     }
 
@@ -68,11 +69,11 @@ public final class Extension {
      *
      * @param configuration
      *         Java/Kotlin style configuration
-     * @see #java()
+     * @see #enableJava()
      */
-    public void java(Action<JavaExtension> configuration) {
+    public void enableJava(Action<JavaExtension> configuration) {
         checkNotNull(configuration);
-        java();
+        enableJava();
         configuration.execute(java);
     }
 
@@ -83,7 +84,7 @@ public final class Extension {
      * is not applied to this project, applies it immediately.
      */
     @CanIgnoreReturnValue
-    public JavaExtension java() {
+    public JavaExtension enableJava() {
         java.enableGeneration();
         return java;
     }
@@ -95,7 +96,7 @@ public final class Extension {
      * not applied to this project, applies it immediately.
      */
     @CanIgnoreReturnValue
-    public JavaScriptExtension javaScript() {
+    public JavaScriptExtension enableJavaScript() {
         javaScript.enableGeneration();
         return javaScript;
     }

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
@@ -92,7 +92,7 @@ class ExtensionTest {
         @Test
         @DisplayName("apply Model Compiler plugin to a Java project")
         void applyModelCompiler() {
-            extension.java();
+            extension.enableJava();
 
             assertApplied(ModelCompilerPlugin.class);
             assertNotApplied(ProtoJsPlugin.class);
@@ -101,7 +101,7 @@ class ExtensionTest {
         @Test
         @DisplayName("apply `java` plugin to a Java project")
         void applyJava() {
-            extension.java();
+            extension.enableJava();
 
             assertApplied(JavaPlugin.class);
         }
@@ -109,25 +109,25 @@ class ExtensionTest {
         @Test
         @DisplayName("apply `com.google.protobuf` plugin to a Java project")
         void applyProtoForJava() {
-            extension.java();
+            extension.enableJava();
 
             assertApplied(ProtobufPlugin.class);
         }
 
         @Test
-        @DisplayName("not apply `java` if already present")
+        @DisplayName("not apply `enableJava` if already present")
         void notApplyJavaIfJavaLib() {
             pluginTarget.apply(GradlePlugin.implementedIn(JavaPlugin.class));
 
             assertApplied(JavaPlugin.class);
 
-            extension.java();
+            extension.enableJava();
         }
 
         @Test
         @DisplayName("apply Proto JS plugin to a JS project")
         void applyProtoJs() {
-            extension.javaScript();
+            extension.enableJavaScript();
 
             assertApplied(ProtoJsPlugin.class);
             assertNotApplied(ModelCompilerPlugin.class);
@@ -136,7 +136,7 @@ class ExtensionTest {
         @Test
         @DisplayName("apply `com.google.protobuf` plugin to a JS project")
         void applyProtoForJs() {
-            extension.javaScript();
+            extension.enableJavaScript();
 
             assertApplied(ProtobufPlugin.class);
         }
@@ -144,8 +144,8 @@ class ExtensionTest {
         @Test
         @DisplayName("apply both Model Compiler and Proto JS plugin to a complex project")
         void combine() {
-            extension.javaScript();
-            extension.java();
+            extension.enableJavaScript();
+            extension.enableJava();
 
             assertApplied(JavaPlugin.class);
             assertApplied(ProtoJsPlugin.class);
@@ -155,7 +155,7 @@ class ExtensionTest {
         @Test
         @DisplayName("add server dependencies if required")
         void server() {
-            extension.java().server();
+            extension.enableJava().server();
 
             assertApplied(JavaPlugin.class);
             assertThat(dependencyTarget.dependencies()).contains(serverDependency());
@@ -164,7 +164,7 @@ class ExtensionTest {
         @Test
         @DisplayName("add client dependencies if required")
         void client() {
-            extension.java().client();
+            extension.enableJava().client();
 
             IterableSubject assertDependencies = assertThat(dependencyTarget.dependencies());
             assertDependencies.contains(clientDependency());
@@ -174,7 +174,7 @@ class ExtensionTest {
         @Test
         @DisplayName("declare `generated` directory a source root")
         void declareGeneratedDirectory() {
-            extension.java();
+            extension.enableJava();
 
             assertApplied(JavaPlugin.class);
             ImmutableSet<Path> declaredPaths = codeLayout.javaSourceDirs();
@@ -184,7 +184,7 @@ class ExtensionTest {
         @Test
         @DisplayName("declare gRPC dependencies when code gen is required")
         void grpcDeps() {
-            extension.java().setGrpc(true);
+            extension.enableJava().setGrpc(true);
 
             assertApplied(JavaPlugin.class);
             assertThat(dependencyTarget.dependencies()).contains(GRPC_DEPENDENCY);
@@ -223,7 +223,7 @@ class ExtensionTest {
             @DisplayName("with an action")
             void action() {
                 AtomicBoolean executedAction = new AtomicBoolean(false);
-                extension.java(javaExtension -> {
+                extension.enableJava(javaExtension -> {
                     boolean defaultValue = javaExtension.getGrpc();
                     assertThat(defaultValue).isFalse();
 
@@ -241,7 +241,7 @@ class ExtensionTest {
             @DisplayName("with a closure")
             void closure() {
                 AtomicBoolean executedClosure = new AtomicBoolean(false);
-                extension.java(ConsumerClosure.<JavaExtension>closure(javaExtension -> {
+                extension.enableJava(ConsumerClosure.<JavaExtension>closure(javaExtension -> {
                     boolean defaultValue = javaExtension.getGrpc();
                     assertThat(defaultValue).isFalse();
 

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
@@ -175,12 +175,12 @@ class SpineBootstrapPluginTest {
     }
 
     private void configureJavaGeneration() {
-        writeConfigGradle("spine.java()");
+        writeConfigGradle("spine.enableJava()");
     }
 
     private void configureJsGeneration() {
         writeConfigGradle(
-                "spine.javaScript()",
+                "spine.enableJavaScript()",
                 "compileJava.enabled = false"
         );
     }
@@ -188,7 +188,7 @@ class SpineBootstrapPluginTest {
     @SuppressWarnings("CheckReturnValue")
     private void configureJavaClient() {
         writeConfigGradle(
-                "spine.java().client()"
+                "spine.enableJava().client()"
         );
         project.addProtoFile("client.proto");
     }
@@ -196,7 +196,7 @@ class SpineBootstrapPluginTest {
     @SuppressWarnings("CheckReturnValue")
     private void configureJavaServer() {
         writeConfigGradle(
-                "spine.java().server()"
+                "spine.enableJava().server()"
         );
         project.addProtoFile("server.proto");
     }
@@ -205,7 +205,7 @@ class SpineBootstrapPluginTest {
     private void configureGrpc() {
         writeConfigGradle(
                 "spine {",
-                "    java {",
+                "    enableJava {",
                 "        grpc = true",
                 "    }",
                 "}"


### PR DESCRIPTION
This PR makes the Bootstrap Gradle DSL easier to understand:
 - instead of `spine.java()`, we now write `spine.enableJava()`;
 - instead of `spine.javaScript()`, we now write `spine.enableJavaScript()`.