### PR TITLE
Disable Java code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,23 @@ However, if users would like to declare gRPC services of their own, they may use
 configuration to set up the generation seamlessly:
 ```gradle
 spine.enableJava {
-    grpc = true
+    withGrpcGeneration()
     client() // or server()
 }
 ```
 
 Note that it is required to enable mark the module as either `client()` or `server()`. Otherwise, 
 the user would have to add all the gRPC-related dependencies on their own.
+
+### Disable code generation
+
+Sometimes, the users might not want any Java code to be generated. For such cases, the plugin 
+provides following configuration opportunity:
+```gradle
+spine.enableJava.withoutCodeGeneration()
+```
+This way, no Java code will be generated at all, including Protobuf messages, gRPC services, 
+and Validating Builders.
 
 ## JavaScript Projects
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ the user would have to add all the gRPC-related dependencies on their own.
 Sometimes, the users might not want any Java code to be generated. For such cases, the plugin 
 provides following configuration opportunity:
 ```gradle
-spine.enableJava.withoutCodeGeneration()
+spine.enableJava().withoutCodeGeneration()
 ```
 This way, no Java code will be generated at all, including Protobuf messages, gRPC services, 
 and Validating Builders.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ However, if users would like to declare gRPC services of their own, they may use
 configuration to set up the generation seamlessly:
 ```gradle
 spine.enableJava {
-    withGrpcGeneration()
+    codegen {
+        grpc = true
+    }
     client() // or server()
 }
 ```
@@ -66,10 +68,25 @@ the user would have to add all the gRPC-related dependencies on their own.
 Sometimes, the users might not want any Java code to be generated. For such cases, the plugin 
 provides following configuration opportunity:
 ```gradle
-spine.enableJava().withoutCodeGeneration()
+spine.enableJava {
+    codegen {
+        protobuf = false
+        spine = false
+    }
+}
 ```
 This way, no Java code will be generated at all, including Protobuf messages, gRPC services, 
-and Validating Builders.
+validating builders, and rejections.
+
+A user also may leave the Java Protobuf codegen enabled, but only turn off Spine-specific code 
+generation:
+```gradle
+spine.enableJava {
+    codegen {
+        spine = false
+    }
+}
+```
 
 ## JavaScript Projects
 

--- a/gradle/plugin.gradle
+++ b/gradle/plugin.gradle
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-ext.pluginVersion = '0.15.3'
+ext.pluginVersion = spineVersion
 
 project.gradlePlugin {
     it.plugins {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.0.0-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-plugin:1.0.0-pre7`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -15,7 +15,7 @@
 1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.7
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.2
+1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.3
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.gradle **Name:** osdetector-gradle-plugin **Version:** 1.4.0
@@ -43,17 +43,15 @@
      * **POM Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **POM License: BSD 3-Clause** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.squareup **Name:** javapoet **Version:** 1.11.0
      * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
@@ -88,7 +86,7 @@
 1. **Group:** org.apache.maven **Name:** maven-plugin-api **Version:** 3.2.1
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -173,19 +171,19 @@
 1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.8.5
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.errorprone **Name:** error_prone_annotation **Version:** 2.3.2
+1. **Group:** com.google.errorprone **Name:** error_prone_annotation **Version:** 2.3.3
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.2
+1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.3
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.errorprone **Name:** error_prone_check_api **Version:** 2.3.2
+1. **Group:** com.google.errorprone **Name:** error_prone_check_api **Version:** 2.3.3
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.errorprone **Name:** error_prone_core **Version:** 2.3.2
+1. **Group:** com.google.errorprone **Name:** error_prone_core **Version:** 2.3.3
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.errorprone **Name:** error_prone_type_annotations **Version:** 2.3.2
+1. **Group:** com.google.errorprone **Name:** error_prone_type_annotations **Version:** 2.3.3
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.errorprone **Name:** javac **Version:** 9+181-r4173-1
@@ -220,28 +218,26 @@
      * **POM Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **POM License: BSD 3-Clause** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1. **Group:** com.google.truth **Name:** truth **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.43
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.googlecode.java-diff-utils **Name:** diffutils **Version:** 1.3.0
@@ -294,10 +290,10 @@
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.11.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.13.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.11.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.13.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
 1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
@@ -332,7 +328,7 @@
      * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -405,23 +401,23 @@
      * **POM Project URL:** [https://github.com/junit-pioneer/junit-pioneer](https://github.com/junit-pioneer/junit-pioneer)
      * **POM License: The MIT License** - [https://github.com/junit-pioneer/junit-pioneer/blob/master/LICENSE](https://github.com/junit-pioneer/junit-pioneer/blob/master/LICENSE)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.4.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.4.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.4.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.4.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.4.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.4.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.4.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.4.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.4.0
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.4.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
 
@@ -439,6 +435,12 @@
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** org.ow2.asm **Name:** asm **Version:** 7.0
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 7.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
      * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
@@ -480,4 +482,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Apr 22 15:41:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 25 17:10:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -480,4 +480,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Apr 19 18:38:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 19 18:54:33 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -55,7 +55,7 @@
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.11.0
      * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -249,7 +249,7 @@
      * **POM Project URL:** [http://code.google.com/p/java-diff-utils/](http://code.google.com/p/java-diff-utils/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.11.0
      * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -480,4 +480,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 18 12:14:35 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 19 18:38:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -480,4 +480,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Apr 19 18:54:33 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 22 14:17:04 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -480,4 +480,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Apr 22 14:17:04 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 22 15:41:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/CodeGenExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/CodeGenExtension.java
@@ -83,7 +83,7 @@ abstract class CodeGenExtension implements Logging {
     /**
      * Obtains the dependency container associated with this extension.
      */
-    final Dependant dependencyTarget() {
+    final Dependant dependant() {
         return dependant;
     }
 

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaCodegenExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaCodegenExtension.java
@@ -31,6 +31,9 @@ import org.gradle.api.Project;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.tools.gradle.protoc.ProtocPlugin.called;
 
+/**
+ * A Gradle extension nested in {@link JavaExtension} which configures Java code generation.
+ */
 public final class JavaCodegenExtension {
 
     private static final ProtocPlugin JAVA_PLUGIN = called(Name.java);
@@ -53,6 +56,9 @@ public final class JavaCodegenExtension {
         this.dependant = dependant;
     }
 
+    /**
+     * Creates a new instance of the extension.
+     */
     public static JavaCodegenExtension of(Project project, Dependant dependant) {
         checkNotNull(project);
         checkNotNull(dependant);
@@ -72,6 +78,13 @@ public final class JavaCodegenExtension {
         return spine;
     }
 
+    /**
+     * Enables or disables Protobuf to Java code generation.
+     *
+     * <p>Enabled by default.
+     *
+     * @param protobuf {@code true} to enable, {@code false} to disable
+     */
     public void setProtobuf(boolean protobuf) {
         this.protobuf = protobuf;
         if (protobuf) {
@@ -81,6 +94,13 @@ public final class JavaCodegenExtension {
         }
     }
 
+    /**
+     * Enables or disables gRPC stub generation.
+     *
+     * <p>Disabled by default.
+     *
+     * @param grpc {@code true} to enable, {@code false} to disable
+     */
     public void setGrpc(boolean grpc) {
         this.grpc = grpc;
         switchPlugin(GRPC_PLUGIN, grpc);
@@ -96,6 +116,16 @@ public final class JavaCodegenExtension {
            .forEach(dependant::implementation);
     }
 
+    /**
+     * Enables or disables Spine-specific Java code generation.
+     *
+     * <p>Enabled by default.
+     *
+     * <p>If enabled, validating builders and rejections will be generated and the generated Java
+     * code will be tweaked by the Spine Protobuf compiler plugin.
+     *
+     * @param spine {@code true} to enable, {@code false} to disable
+     */
     public void setSpine(boolean spine) {
         this.spine = spine;
         switchPlugin(SPINE_PLUGIN, spine);

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaCodegenExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaCodegenExtension.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gradle.bootstrap;
+
+import io.spine.tools.gradle.compiler.Extension;
+import io.spine.tools.gradle.protoc.ProtobufGenerator;
+import io.spine.tools.gradle.protoc.ProtocPlugin;
+import io.spine.tools.gradle.protoc.ProtocPlugin.Name;
+import org.gradle.api.Project;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.tools.gradle.protoc.ProtocPlugin.called;
+
+public final class JavaCodegenExtension {
+
+    private static final ProtocPlugin JAVA_PLUGIN = called(Name.java);
+    private static final ProtocPlugin GRPC_PLUGIN = called(Name.grpc);
+    private static final ProtocPlugin SPINE_PLUGIN = called(Name.spineProtoc);
+
+    private final Project project;
+    private final ProtobufGenerator protobufGenerator;
+
+    private boolean protobuf = true;
+    private boolean grpc = false;
+    private boolean spine = false;
+
+    private JavaCodegenExtension(Project project, ProtobufGenerator protobufGenerator) {
+        this.project = project;
+        this.protobufGenerator = protobufGenerator;
+    }
+
+    public static JavaCodegenExtension of(Project project) {
+        checkNotNull(project);
+        ProtobufGenerator generator = new ProtobufGenerator(project);
+        return new JavaCodegenExtension(project, generator);
+    }
+
+    public boolean getProtobuf() {
+        return protobuf;
+    }
+
+    public boolean getGrpc() {
+        return grpc;
+    }
+
+    public boolean getSpine() {
+        return spine;
+    }
+
+    public void setProtobuf(boolean protobuf) {
+        this.protobuf = protobuf;
+        if (protobuf) {
+            protobufGenerator.enableBuiltIn(JAVA_PLUGIN);
+        } else {
+            protobufGenerator.disableBuiltIn(JAVA_PLUGIN);
+        }
+    }
+
+    public void setGrpc(boolean grpc) {
+        this.grpc = grpc;
+        switchPlugin(GRPC_PLUGIN, grpc);
+    }
+
+    public void setSpine(boolean spine) {
+        this.spine = spine;
+        switchPlugin(SPINE_PLUGIN, spine);
+        Extension modelCompilerExtension = project.getExtensions()
+                                                  .getByType(Extension.class);
+        modelCompilerExtension.generateValidatingBuilders = spine;
+    }
+
+    private void switchPlugin(ProtocPlugin plugin, boolean enabled) {
+        if (enabled) {
+            protobufGenerator.enablePlugin(plugin);
+        } else {
+            protobufGenerator.disablePlugin(plugin);
+        }
+    }
+}

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaCodegenExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaCodegenExtension.java
@@ -21,6 +21,8 @@
 package io.spine.tools.gradle.bootstrap;
 
 import io.spine.tools.gradle.compiler.Extension;
+import io.spine.tools.gradle.config.Ext;
+import io.spine.tools.gradle.project.Dependant;
 import io.spine.tools.gradle.protoc.ProtobufGenerator;
 import io.spine.tools.gradle.protoc.ProtocPlugin;
 import io.spine.tools.gradle.protoc.ProtocPlugin.Name;
@@ -37,20 +39,25 @@ public final class JavaCodegenExtension {
 
     private final Project project;
     private final ProtobufGenerator protobufGenerator;
+    private final Dependant dependant;
 
     private boolean protobuf = true;
     private boolean grpc = false;
     private boolean spine = false;
 
-    private JavaCodegenExtension(Project project, ProtobufGenerator protobufGenerator) {
+    private JavaCodegenExtension(Project project,
+                                 ProtobufGenerator protobufGenerator,
+                                 Dependant dependant) {
         this.project = project;
         this.protobufGenerator = protobufGenerator;
+        this.dependant = dependant;
     }
 
-    public static JavaCodegenExtension of(Project project) {
+    public static JavaCodegenExtension of(Project project, Dependant dependant) {
         checkNotNull(project);
+        checkNotNull(dependant);
         ProtobufGenerator generator = new ProtobufGenerator(project);
-        return new JavaCodegenExtension(project, generator);
+        return new JavaCodegenExtension(project, generator, dependant);
     }
 
     public boolean getProtobuf() {
@@ -77,6 +84,16 @@ public final class JavaCodegenExtension {
     public void setGrpc(boolean grpc) {
         this.grpc = grpc;
         switchPlugin(GRPC_PLUGIN, grpc);
+        if (grpc) {
+            addGrpcDependencies();
+        }
+    }
+
+    private void addGrpcDependencies() {
+        Ext.of(project)
+           .artifacts()
+           .grpc()
+           .forEach(dependant::implementation);
     }
 
     public void setSpine(boolean spine) {

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaCodegenExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaCodegenExtension.java
@@ -53,7 +53,7 @@ public final class JavaCodegenExtension implements Logging {
 
     private boolean protobuf = true;
     private boolean grpc = false;
-    private boolean spine = false;
+    private boolean spine = true;
 
     private JavaCodegenExtension(Project project,
                                  ProtobufGenerator protobufGenerator,

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -22,9 +22,7 @@ package io.spine.tools.gradle.bootstrap;
 
 import groovy.lang.Closure;
 import io.spine.tools.gradle.GeneratedSourceRoot;
-import io.spine.tools.gradle.config.Ext;
 import io.spine.tools.gradle.config.SpineDependency;
-import io.spine.tools.gradle.project.Dependant;
 import io.spine.tools.gradle.project.SourceSuperset;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -48,7 +46,7 @@ public final class JavaExtension extends CodeGenExtension {
         super(builder);
         this.project = builder.project();
         this.directoryStructure = builder.sourceSuperset();
-        this.codegen = JavaCodegenExtension.of(project);
+        this.codegen = JavaCodegenExtension.of(project, dependant());
     }
 
     @Override
@@ -60,17 +58,8 @@ public final class JavaExtension extends CodeGenExtension {
         excludeProtobufLite();
     }
 
-    private void addGrpcDependencies() {
-        // TODO:2019-04-22:dmytro.dashenkov: Add dependencies when required.
-        Dependant dependencyTarget = dependencyTarget();
-        Ext.of(project)
-           .artifacts()
-           .grpc()
-           .forEach(dependencyTarget::implementation);
-    }
-
     private void excludeProtobufLite() {
-        dependencyTarget().exclude(protobufLite());
+        dependant().exclude(protobufLite());
     }
 
     public JavaCodegenExtension getCodegen() {
@@ -104,7 +93,7 @@ public final class JavaExtension extends CodeGenExtension {
     }
 
     private void dependOn(SpineDependency module) {
-        dependencyTarget().compile(module.ofVersion(spineVersion()));
+        dependant().compile(module.ofVersion(spineVersion()));
     }
 
     private void addSourceSets() {

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -31,6 +31,7 @@ import org.gradle.api.Project;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.tools.gradle.ProtobufDependencies.protobufLite;
+import static io.spine.tools.gradle.protoc.ProtocPlugin.Name.grpc;
 import static io.spine.tools.gradle.protoc.ProtocPlugin.Name.java;
 import static io.spine.tools.gradle.protoc.ProtocPlugin.called;
 
@@ -40,12 +41,12 @@ import static io.spine.tools.gradle.protoc.ProtocPlugin.called;
 public final class JavaExtension extends CodeGenExtension {
 
     private static final ProtocPlugin JAVA_PLUGIN = called(java);
-    private static final ProtocPlugin GRPC_PLUGIN = called(ProtocPlugin.Name.grpc);
+    private static final ProtocPlugin GRPC_PLUGIN = called(grpc);
 
     private final Project project;
     private final SourceSuperset directoryStructure;
 
-    private boolean grpc = false;
+    private boolean grpcGen = false;
     private boolean codegen = true;
 
     private JavaExtension(Builder builder) {
@@ -73,7 +74,7 @@ public final class JavaExtension extends CodeGenExtension {
      * @see #withGrpcGeneration()
      */
     public boolean getGrpc() {
-        return grpc;
+        return grpcGen;
     }
 
     /**
@@ -89,7 +90,7 @@ public final class JavaExtension extends CodeGenExtension {
      * Enables the gRPC stub generation.
      */
     public void withGrpcGeneration() {
-        this.grpc = true;
+        this.grpcGen = true;
         checkGrpcRequestValid();
         protobufGenerator().enablePlugin(GRPC_PLUGIN);
         addGrpcDependencies();
@@ -105,13 +106,13 @@ public final class JavaExtension extends CodeGenExtension {
         protobufGenerator().disableBuiltIn(JAVA_PLUGIN);
         Extension modelCompilerExtension = project.getExtensions().getByType(Extension.class);
         modelCompilerExtension.generateValidatingBuilders = false;
-        if (grpc) {
+        if (grpcGen) {
             protobufGenerator().disablePlugin(GRPC_PLUGIN);
         }
     }
 
     private void checkGrpcRequestValid() {
-        if (!codegen && grpc) {
+        if (!codegen && grpcGen) {
             _warn("Requested gRPC code generation. " +
                           "However, Java code generation is disabled for this project. " +
                           "No Java code will be generated.");

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -92,8 +92,10 @@ public final class JavaExtension extends CodeGenExtension {
     public void withGrpcGeneration() {
         this.grpcGen = true;
         checkGrpcRequestValid();
-        protobufGenerator().enablePlugin(GRPC_PLUGIN);
-        addGrpcDependencies();
+        if (codegen) {
+            protobufGenerator().enablePlugin(GRPC_PLUGIN);
+            addGrpcDependencies();
+        }
     }
 
     /**

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -90,11 +90,13 @@ public final class JavaExtension extends CodeGenExtension {
      * Enables the gRPC stub generation.
      */
     public void withGrpcGeneration() {
-        this.grpcGen = true;
+        grpcGen = true;
         checkGrpcRequestValid();
         if (codegen) {
             protobufGenerator().enablePlugin(GRPC_PLUGIN);
             addGrpcDependencies();
+        } else {
+            grpcGen = false;
         }
     }
 
@@ -110,6 +112,7 @@ public final class JavaExtension extends CodeGenExtension {
         modelCompilerExtension.generateValidatingBuilders = false;
         if (grpcGen) {
             protobufGenerator().disablePlugin(GRPC_PLUGIN);
+            grpcGen = false;
         }
     }
 

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/SpinePluginScripts.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/SpinePluginScripts.java
@@ -23,7 +23,19 @@ package io.spine.tools.gradle.bootstrap;
 import io.spine.io.Resource;
 import io.spine.tools.gradle.PluginScript;
 
-public class SpinePluginScripts {
+/**
+ * A factory of Spine-specific {@link PluginScript}s.
+ *
+ * <p>These scripts are read from the plugin resources at runtime. When building the plugin,
+ * the script files are copied from the {@code config} submodule.
+ */
+public final class SpinePluginScripts {
+
+    /**
+     * Prevents the utility class instantiation.
+     */
+    private SpinePluginScripts() {
+    }
 
     /**
      * Obtains the {@code dependencies.gradle} script.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/SpinePluginTarget.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/SpinePluginTarget.java
@@ -30,7 +30,12 @@ import org.gradle.api.plugins.JavaPlugin;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-
+/**
+ * A {@link PluginTarget} which applies Spine Gradle plugins.
+ *
+ * <p>Provides convenience methods for the Model Compiler plugin, Proto JS plugin, and the Protobuf
+ * Gradle plugin.
+ */
 public final class SpinePluginTarget implements PluginTarget {
 
     private final PluginTarget delegate;

--- a/plugin/src/main/java/io/spine/tools/gradle/protoc/ProtocPlugin.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/protoc/ProtocPlugin.java
@@ -71,6 +71,7 @@ public final class ProtocPlugin {
     public enum Name {
         java,
         js,
-        grpc
+        grpc,
+        spineProtoc
     }
 }

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
@@ -236,12 +236,15 @@ class ExtensionTest {
     @DisplayName("allow to configure")
     class Configuration {
 
+        private static final String WITH_AN_ACTION = "with an action";
+        private static final String WITH_A_CLOSURE = "with a closure";
+
         @Nested
-        @DisplayName("gRPC code gen for Java")
-        class GrpcJava {
+        @DisplayName("Java")
+        class Java {
 
             @Test
-            @DisplayName("with an action")
+            @DisplayName(WITH_AN_ACTION)
             void action() {
                 AtomicBoolean executedAction = new AtomicBoolean(false);
                 extension.enableJava(javaExtension -> {
@@ -260,7 +263,7 @@ class ExtensionTest {
             }
 
             @Test
-            @DisplayName("with a closure")
+            @DisplayName(WITH_A_CLOSURE)
             void closure() {
                 AtomicBoolean executedClosure = new AtomicBoolean(false);
                 extension.enableJava(ConsumerClosure.<JavaExtension>closure(javaExtension -> {
@@ -275,6 +278,48 @@ class ExtensionTest {
 
                     executedClosure.set(true);
                 }));
+                assertTrue(executedClosure.get());
+            }
+        }
+
+        @Nested
+        @DisplayName("Java codegen")
+        class CodegenJava {
+            @Test
+            @DisplayName(WITH_AN_ACTION)
+            void action() {
+                AtomicBoolean executedAction = new AtomicBoolean(false);
+                JavaExtension javaExtension = ExtensionTest.this.extension.enableJava();
+                javaExtension.codegen(codegen -> {
+                    boolean defaultValue = codegen.getSpine();
+                    assertThat(defaultValue).isFalse();
+
+                    codegen.setSpine(true);
+
+                    boolean newValue = codegen.getSpine();
+                    assertThat(newValue).isTrue();
+
+                    executedAction.set(true);
+                });
+                assertTrue(executedAction.get());
+            }
+
+            @Test
+            @DisplayName(WITH_A_CLOSURE)
+            void closure() {
+                AtomicBoolean executedClosure = new AtomicBoolean(false);
+                extension.enableJava().codegen(ConsumerClosure.<JavaCodegenExtension>closure(
+                        codegen -> {
+                            boolean defaultValue = codegen.getSpine();
+                            assertThat(defaultValue).isFalse();
+
+                            codegen.setSpine(true);
+
+                            boolean newValue = codegen.getSpine();
+                            assertThat(newValue).isTrue();
+
+                            executedClosure.set(true);
+                        }));
                 assertTrue(executedClosure.get());
             }
         }

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
@@ -191,12 +191,21 @@ class ExtensionTest {
         }
 
         @Test
-        @DisplayName("declare gRPC dependencies when code gen is required")
+        @DisplayName("declare gRPC dependencies when codegen is required")
         void grpcDeps() {
-            extension.enableJava().setGrpc(true);
+            extension.enableJava().withGrpcGeneration();
 
             assertApplied(JavaPlugin.class);
             assertThat(dependencyTarget.dependencies()).contains(GRPC_DEPENDENCY);
+        }
+
+        @Test
+        @DisplayName("disable Java code generation in Java projects")
+        void disableCodegen() {
+            JavaExtension javaExtension = ExtensionTest.this.extension.enableJava();
+            assertTrue(javaExtension.getCodegen());
+            javaExtension.withoutCodeGeneration();
+            assertFalse(javaExtension.getCodegen());
         }
 
         private String serverDependency() {
@@ -236,7 +245,7 @@ class ExtensionTest {
                     boolean defaultValue = javaExtension.getGrpc();
                     assertThat(defaultValue).isFalse();
 
-                    javaExtension.setGrpc(true);
+                    javaExtension.withGrpcGeneration();
 
                     boolean newValue = javaExtension.getGrpc();
                     assertThat(newValue).isTrue();
@@ -254,7 +263,7 @@ class ExtensionTest {
                     boolean defaultValue = javaExtension.getGrpc();
                     assertThat(defaultValue).isFalse();
 
-                    javaExtension.setGrpc(true);
+                    javaExtension.withGrpcGeneration();
 
                     boolean newValue = javaExtension.getGrpc();
                     assertThat(newValue).isTrue();

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
@@ -205,6 +205,18 @@ class SpineBootstrapPluginTest {
         assertFalse(exists(compiledClasses));
     }
 
+    @Test
+    @DisplayName("disable rejection throwable generation")
+    void ignoreRejections() {
+        configureJavaWithoutProtoOrSpine();
+        GradleProject project = this.project
+                .addProtoFile("restaurant_rejections.proto")
+                .build();
+        project.executeTask(build);
+        Path compiledClasses = compiledJavaClasses();
+        assertFalse(exists(compiledClasses));
+    }
+
     private void noAdditionalConfig() {
         writeConfigGradle();
     }
@@ -249,7 +261,7 @@ class SpineBootstrapPluginTest {
     }
 
     private void configureJavaWithoutGen() {
-        writeConfigGradle("spine.enableJava().withoutCodeGeneration()");
+        writeConfigGradle("spine.enableJava().codegen.protobuf = false");
     }
 
     private void configureJavaAndGrpcWithoutGen() {
@@ -258,6 +270,16 @@ class SpineBootstrapPluginTest {
                 "    codegen {",
                 "        protobuf = false",
                 "        grpc = true",
+                "    }",
+                "}");
+    }
+
+    private void configureJavaWithoutProtoOrSpine() {
+        writeConfigGradle(
+                "spine.enableJava {",
+                "    codegen {",
+                "        protobuf = false",
+                "        spine = false",
                 "    }",
                 "}");
     }

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
@@ -264,6 +264,8 @@ class SpineBootstrapPluginTest {
         writeConfigGradle("spine.enableJava().codegen.protobuf = false");
     }
 
+    @SuppressWarnings("DuplicateStringLiteralInspection")
+        // Part of the file contents may be duplicated.
     private void configureJavaAndGrpcWithoutGen() {
         writeConfigGradle(
                 "spine.enableJava {",
@@ -274,6 +276,8 @@ class SpineBootstrapPluginTest {
                 "}");
     }
 
+    @SuppressWarnings("DuplicateStringLiteralInspection")
+        // Part of the file contents may be duplicated.
     private void configureJavaWithoutProtoOrSpine() {
         writeConfigGradle(
                 "spine.enableJava {",

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
@@ -33,7 +33,6 @@ import org.junitpioneer.jupiter.TempDirectory;
 import org.junitpioneer.jupiter.TempDirectory.TempDir;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Set;
@@ -42,8 +41,10 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.spine.tools.gradle.TaskName.build;
 import static io.spine.tools.gradle.TaskName.generateJsonParsers;
 import static io.spine.tools.gradle.TaskName.generateValidatingBuilders;
+import static java.nio.file.Files.exists;
 import static java.util.Collections.emptySet;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -83,7 +84,7 @@ class SpineBootstrapPluginTest {
         project.build()
                .executeTask(build);
         Path compiledClasses = compiledJavaClasses();
-        if (Files.exists(compiledClasses)) {
+        if (exists(compiledClasses)) {
             File compiledClassesDirectory = compiledClasses.toFile();
             assertThat(compiledClassesDirectory.list()).isEmpty();
         }
@@ -188,6 +189,22 @@ class SpineBootstrapPluginTest {
         assertThat(resourceFiles).contains(resourceName);
     }
 
+    @Test
+    @DisplayName("disable Java codegen")
+    void disableJava() {
+        configureJavaWithoutGen();
+        Path compiledClasses = compiledJavaClasses();
+        assertFalse(exists(compiledClasses));
+    }
+
+    @Test
+    @DisplayName("disable Java codegen and ignore gRPC settings")
+    void disableJavaAndGrpc() {
+        configureJavaAndGrpcWithoutGen();
+        Path compiledClasses = compiledJavaClasses();
+        assertFalse(exists(compiledClasses));
+    }
+
     private void noAdditionalConfig() {
         writeConfigGradle();
     }
@@ -224,11 +241,23 @@ class SpineBootstrapPluginTest {
         writeConfigGradle(
                 "spine {",
                 "    enableJava {",
-                "        grpc = true",
+                "        withGrpcGeneration()",
                 "    }",
                 "}"
         );
         project.addProtoFile("restaurant.proto");
+    }
+
+    private void configureJavaWithoutGen() {
+        writeConfigGradle("spine.enableJava().withoutCodeGeneration()");
+    }
+
+    private void configureJavaAndGrpcWithoutGen() {
+        writeConfigGradle(
+                "spine.enableJava {",
+                "    withoutCodeGeneration()",
+                "    withGrpcGeneration()",
+                "}");
     }
 
     @SuppressWarnings("CheckReturnValue")

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
@@ -241,7 +241,7 @@ class SpineBootstrapPluginTest {
         writeConfigGradle(
                 "spine {",
                 "    enableJava {",
-                "        withGrpcGeneration()",
+                "        codegen.grpc = true",
                 "    }",
                 "}"
         );
@@ -255,8 +255,10 @@ class SpineBootstrapPluginTest {
     private void configureJavaAndGrpcWithoutGen() {
         writeConfigGradle(
                 "spine.enableJava {",
-                "    withoutCodeGeneration()",
-                "    withGrpcGeneration()",
+                "    codegen {",
+                "        protobuf = false",
+                "        grpc = true",
+                "    }",
                 "}");
     }
 

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/given/ExtensionTestEnv.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/given/ExtensionTestEnv.java
@@ -28,7 +28,7 @@ import org.gradle.api.plugins.ExtraPropertiesExtension;
 
 import java.util.Map;
 
-public final class ExtensionTextEnv {
+public final class ExtensionTestEnv {
 
     public static final String GRPC_DEPENDENCY = "io.foo.bar.grpc:fake-dependency:6.14";
 
@@ -47,7 +47,7 @@ public final class ExtensionTextEnv {
     /**
      * Prevents the utility class instantiation.
      */
-    private ExtensionTextEnv() {
+    private ExtensionTestEnv() {
     }
 
     public static void addExt(Project project) {

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/given/ExtensionTextEnv.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/given/ExtensionTextEnv.java
@@ -21,6 +21,8 @@
 package io.spine.tools.gradle.bootstrap.given;
 
 import com.google.common.collect.ImmutableMap;
+import io.spine.tools.gradle.compiler.Extension;
+import io.spine.tools.gradle.compiler.ModelCompilerPlugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 
@@ -53,5 +55,8 @@ public final class ExtensionTextEnv {
                                               .getExtraProperties();
         ext.set("spineVersion", spineVersion);
         ext.set("deps", deps);
+
+        project.getExtensions()
+               .add(ModelCompilerPlugin.extensionName(), new Extension());
     }
 }

--- a/plugin/src/test/resources/func-test/src/main/proto/restaurant_rejections.proto
+++ b/plugin/src/test/resources/func-test/src/main/proto/restaurant_rejections.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package spine.tools.bootstrap.test;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.tools.bootstrap.test";
+option java_outer_classname = "RestaurantRejections";
+
+message RunOutOfIngredient {
+
+    string ingredient_name = 1;
+}

--- a/version.gradle
+++ b/version.gradle
@@ -29,7 +29,7 @@
  * already in the root directory.
  */
 
-final def SPINE_VERSION = '1.0.0-SNAPSHOT'
+final def SPINE_VERSION = '1.0.0-pre7'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR introduces the opportunity for the plugin users to disable Protobuf Java code generation in Java modules.

In order to do that, apply the following config:
```gradle
spine.enableJava().codegen {
    protobuf = false
    grpc = false
    spine = false
}
```

Note that the three properties can be configured separately. Though, such a configuration should be performed with caution, as it may break the compilation of Java code.

This PR also updates Spine modules to version 1.0.0-pre7 and the plugin with the respective version in published.