### PR TITLE
Add `testutil-server` dependency automatically.

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.0.0-pre7`
+# Dependencies of `io.spine.tools:spine-plugin:1.0.0-SNAPSHOT`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -482,4 +482,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 25 17:10:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 14 17:55:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
@@ -32,6 +32,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.tools.gradle.ConfigurationName.TEST_IMPLEMENTATION;
 import static org.gradle.util.ConfigureUtil.configure;
 
 /**
@@ -91,7 +92,7 @@ public final class Extension {
         java.enableGeneration();
         String spineVersion = java.spineVersion();
         Artifact testlib = SpineDependency.testlib().ofVersion(spineVersion);
-        java.dependant().compile(testlib);
+        java.dependant().depend(TEST_IMPLEMENTATION, testlib.notation());
         return java;
     }
 

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
@@ -22,6 +22,8 @@ package io.spine.tools.gradle.bootstrap;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import groovy.lang.Closure;
+import io.spine.tools.gradle.Artifact;
+import io.spine.tools.gradle.config.SpineDependency;
 import io.spine.tools.gradle.project.Dependant;
 import io.spine.tools.gradle.project.PluginTarget;
 import io.spine.tools.gradle.project.SourceSuperset;
@@ -81,11 +83,15 @@ public final class Extension {
      * Marks this project as a Java project and configures the Java code generation.
      *
      * <p>Enables the Java code generation from Protobuf. If the {@code spine-model-compiler} plugin
-     * is not applied to this project, applies it immediately.
+     * is not applied to this project, applies it immediately. Also adds the
+     * {@code io.spine:spine-testlib}
      */
     @CanIgnoreReturnValue
     public JavaExtension enableJava() {
         java.enableGeneration();
+        String spineVersion = java.spineVersion();
+        Artifact testlib = SpineDependency.testlib().ofVersion(spineVersion);
+        java.dependant().compile(testlib);
         return java;
     }
 

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -77,16 +77,19 @@ public final class JavaExtension extends CodeGenExtension {
     /**
      * Marks this project as a Java client of the system.
      *
-     * <p>Adds the {@code io.spine:spine-client} dependency to the project.
+     * <p>Adds the {@code io.spine:spine-client} and {@code io.spine:spine-testuil-client}
+     * dependencies to the project.
      */
     public void client() {
         dependOn(SpineDependency.client());
+        dependOn(SpineDependency.testUtilClient());
     }
 
     /**
      * Marks this project as a part of a Java server.
      *
-     * <p>Adds the {@code io.spine:spine-server} dependency to the project.
+     * <p>Adds the {@code io.spine:spine-server} and {@code io.spine:spine-testutil-server}
+     * dependencies to the project.
      */
     public void server() {
         dependOn(SpineDependency.server());

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -90,6 +90,7 @@ public final class JavaExtension extends CodeGenExtension {
      */
     public void server() {
         dependOn(SpineDependency.server());
+        dependOn(SpineDependency.testUtilServer());
     }
 
     private void dependOn(SpineDependency module) {

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -21,6 +21,7 @@
 package io.spine.tools.gradle.bootstrap;
 
 import groovy.lang.Closure;
+import io.spine.tools.gradle.ConfigurationName;
 import io.spine.tools.gradle.GeneratedSourceRoot;
 import io.spine.tools.gradle.config.SpineDependency;
 import io.spine.tools.gradle.project.SourceSuperset;
@@ -28,6 +29,8 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.tools.gradle.ConfigurationName.COMPILE;
+import static io.spine.tools.gradle.ConfigurationName.TEST_IMPLEMENTATION;
 import static io.spine.tools.gradle.ProtobufDependencies.protobufLite;
 import static io.spine.tools.gradle.protoc.ProtocPlugin.Name.java;
 import static io.spine.tools.gradle.protoc.ProtocPlugin.called;
@@ -81,8 +84,8 @@ public final class JavaExtension extends CodeGenExtension {
      * dependencies to the project.
      */
     public void client() {
-        dependOn(SpineDependency.client());
-        dependOn(SpineDependency.testUtilClient());
+        dependOn(SpineDependency.client(), COMPILE);
+        dependOn(SpineDependency.testUtilClient(), TEST_IMPLEMENTATION);
     }
 
     /**
@@ -92,12 +95,12 @@ public final class JavaExtension extends CodeGenExtension {
      * dependencies to the project.
      */
     public void server() {
-        dependOn(SpineDependency.server());
-        dependOn(SpineDependency.testUtilServer());
+        dependOn(SpineDependency.server(), COMPILE);
+        dependOn(SpineDependency.testUtilServer(), TEST_IMPLEMENTATION);
     }
 
-    private void dependOn(SpineDependency module) {
-        dependant().compile(module.ofVersion(spineVersion()));
+    private void dependOn(SpineDependency module, ConfigurationName configurationName) {
+        dependant().depend(configurationName, module.ofVersion(spineVersion()).notation());
     }
 
     private void addSourceSets() {

--- a/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
@@ -29,10 +29,12 @@ public final class SpineDependency implements Dependency {
 
     private static final String SPINE_PREFIX = "spine-";
 
-    private static final SpineDependency base = new SpineDependency("base");
-    private static final SpineDependency client = new SpineDependency("client");
-    private static final SpineDependency server = new SpineDependency("server");
-    private static final SpineDependency testUtilServer = new SpineDependency("testutil-server");
+    private static final SpineDependency BASE = new SpineDependency("base");
+    private static final SpineDependency CLIENT = new SpineDependency("client");
+    private static final SpineDependency SERVER = new SpineDependency("server");
+    private static final SpineDependency TEST_UTIL_SERVER = new SpineDependency("testutil-server");
+    private static final SpineDependency TEST_UTIL_CLIENT = new SpineDependency("testutil-client");
+    private static final SpineDependency TESTLIB = new SpineDependency("testlib");
 
     private final String shortName;
 
@@ -44,28 +46,40 @@ public final class SpineDependency implements Dependency {
      * Obtains a dependency on the {@code io.spine:spine-base} module.
      */
     public static SpineDependency base() {
-        return base;
+        return BASE;
     }
 
     /**
      * Obtains a dependency on the {@code io.spine:spine-client} module.
      */
     public static SpineDependency client() {
-        return client;
+        return CLIENT;
     }
 
     /**
      * Obtains a dependency on the {@code io.spine:spine-server} module.
      */
     public static SpineDependency server() {
-        return server;
+        return SERVER;
     }
 
     /**
      * Obtains a dependency on the {@code io.spine:testutil-server} module.
      */
     public static SpineDependency testUtilServer() {
-        return testUtilServer;
+        return TEST_UTIL_SERVER;
+    }
+
+    /**
+     * Obtains a dependency on the {@code io.spine:testutil-client} module.
+     */
+    public static SpineDependency testUtilClient() {
+        return TEST_UTIL_CLIENT;
+    }
+
+
+    public static SpineDependency testlib() {
+        return TESTLIB;
     }
 
     @Override

--- a/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
@@ -32,6 +32,7 @@ public final class SpineDependency implements Dependency {
     private static final SpineDependency base = new SpineDependency("base");
     private static final SpineDependency client = new SpineDependency("client");
     private static final SpineDependency server = new SpineDependency("server");
+    private static final SpineDependency testUtilServer = new SpineDependency("testutil-server");
 
     private final String shortName;
 
@@ -60,8 +61,15 @@ public final class SpineDependency implements Dependency {
         return server;
     }
 
+    /**
+     * Obtains a dependency on the {@code io.spine:testutil-server} module.
+     */
+    public static SpineDependency testUtilServer() {
+        return testUtilServer;
+    }
+
     @Override
-    public  String name() {
+    public String name() {
         return SPINE_PREFIX + shortName;
     }
 

--- a/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
@@ -77,7 +77,6 @@ public final class SpineDependency implements Dependency {
         return TEST_UTIL_CLIENT;
     }
 
-
     public static SpineDependency testlib() {
         return TESTLIB;
     }

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
@@ -111,6 +111,14 @@ class ExtensionTest {
         }
 
         @Test
+        @DisplayName("add `testlib` dependency to a Java project")
+        void addTestlibDependecy() {
+            extension.enableJava();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(testlibDependency());
+        }
+
+        @Test
         @DisplayName("apply `com.google.protobuf` plugin to a Java project")
         void applyProtoForJava() {
             extension.enableJava();
@@ -135,6 +143,15 @@ class ExtensionTest {
 
             assertApplied(ProtoJsPlugin.class);
             assertNotApplied(ModelCompilerPlugin.class);
+        }
+
+        @Test
+        @DisplayName("not add a `testlib` dependency to a JS project")
+        void noTestLibForJs() {
+            extension.enableJavaScript();
+
+            assertThat(dependencyTarget.dependencies())
+                    .doesNotContain(testlibDependency());
         }
 
         @Test
@@ -166,6 +183,24 @@ class ExtensionTest {
         }
 
         @Test
+        @DisplayName("not contain `testutil-server` for enableJava() declaring modules")
+        void notContainTestUtil() {
+            extension.enableJava();
+
+            assertThat(dependencyTarget.dependencies())
+                    .doesNotContain(testUtilServerDependency());
+        }
+
+        @Test
+        @DisplayName("add `testutil-server` dependency for enableJava().server() declaring modules")
+        void testUtilDependencyAdded() {
+            extension.enableJava().server();
+
+            assertThat(dependencyTarget.dependencies())
+                    .contains(testUtilServerDependency());
+        }
+
+        @Test
         @DisplayName("add client dependencies if required")
         void client() {
             extension.enableJava().client();
@@ -173,6 +208,17 @@ class ExtensionTest {
             IterableSubject assertDependencies = assertThat(dependencyTarget.dependencies());
             assertDependencies.contains(clientDependency());
             assertDependencies.doesNotContain(serverDependency());
+        }
+
+        @Test
+        @DisplayName("add `testutil-server` dependencies together with server dependencies")
+        void testUtilServer() {
+            extension.enableJava()
+                     .client();
+
+            IterableSubject assertDependencies = assertThat(dependencyTarget.dependencies());
+            assertDependencies.contains(testUtilClientDependency());
+            assertDependencies.doesNotContain(testUtilServerDependency());
         }
 
         @Test
@@ -191,22 +237,6 @@ class ExtensionTest {
             assertApplied(JavaPlugin.class);
             ImmutableSet<Path> declaredPaths = codeLayout.javaSourceDirs();
             assertThat(declaredPaths).contains(projectDir.resolve("generated"));
-        }
-
-        @Test
-        @DisplayName("not contain `testutil-server` for enableJava() declaring modules")
-        void notContainTestUtil() {
-            extension.enableJava();
-            assertThat(dependencyTarget.dependencies())
-                    .doesNotContain(testUtilDependency());
-        }
-
-        @Test
-        @DisplayName("add `testutil-server` dependency for enableJava().server() declaring modules")
-        void testUtilDependencyAdded() {
-            extension.enableJava().server();
-            assertThat(dependencyTarget.dependencies())
-                    .contains(testUtilDependency());
         }
 
         @Test
@@ -234,12 +264,20 @@ class ExtensionTest {
             return "io.spine:spine-server:" + spineVersion;
         }
 
-        private String testUtilDependency() {
+        private String testUtilServerDependency() {
             return "io.spine:spine-testutil-server:" + spineVersion;
         }
 
         private String clientDependency() {
             return "io.spine:spine-client:" + spineVersion;
+        }
+
+        private String testUtilClientDependency() {
+            return "io.spine:spine-testutil-client:" + spineVersion;
+        }
+
+        private String testlibDependency() {
+            return "io.spine:spine-testlib:" + spineVersion;
         }
 
         private void assertApplied(Class<? extends Plugin<? extends Project>> pluginClass) {
@@ -376,18 +414,19 @@ class ExtensionTest {
             @DisplayName(WITH_A_CLOSURE)
             void closure() {
                 AtomicBoolean executedClosure = new AtomicBoolean(false);
-                extension.enableJava().codegen(ConsumerClosure.<JavaCodegenExtension>closure(
-                        codegen -> {
-                            boolean defaultValue = codegen.getSpine();
-                            assertThat(defaultValue).isTrue();
+                extension.enableJava()
+                         .codegen(ConsumerClosure.<JavaCodegenExtension>closure(
+                                 codegen -> {
+                                     boolean defaultValue = codegen.getSpine();
+                                     assertThat(defaultValue).isTrue();
 
-                            codegen.setSpine(false);
+                                     codegen.setSpine(false);
 
-                            boolean newValue = codegen.getSpine();
-                            assertThat(newValue).isFalse();
+                                     boolean newValue = codegen.getSpine();
+                                     assertThat(newValue).isFalse();
 
-                            executedClosure.set(true);
-                        }));
+                                     executedClosure.set(true);
+                                 }));
                 assertTrue(executedClosure.get());
             }
         }

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
@@ -194,6 +194,22 @@ class ExtensionTest {
         }
 
         @Test
+        @DisplayName("not contain `testutil-server` for enableJava() declaring modules")
+        void notContainTestUtil() {
+            extension.enableJava();
+            assertThat(dependencyTarget.dependencies())
+                    .doesNotContain(testUtilDependency());
+        }
+
+        @Test
+        @DisplayName("add `testutil-server` dependency for enableJava().server() declaring modules")
+        void testUtilDependencyAdded() {
+            extension.enableJava().server();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(testUtilDependency());
+        }
+
+        @Test
         @DisplayName("declare gRPC dependencies when codegen is required")
         void grpcDeps() {
             extension.enableJava()
@@ -216,6 +232,10 @@ class ExtensionTest {
 
         private String serverDependency() {
             return "io.spine:spine-server:" + spineVersion;
+        }
+
+        private String testUtilDependency() {
+            return "io.spine:spine-testutil-server:" + spineVersion;
         }
 
         private String clientDependency() {

--- a/version.gradle
+++ b/version.gradle
@@ -29,7 +29,7 @@
  * already in the root directory.
  */
 
-final def SPINE_VERSION = '1.0.0-pre7'
+final def SPINE_VERSION = '1.0.0-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR fixes https://github.com/SpineEventEngine/bootstrap/issues/15.

Now, if `spine.enableJava().server()` is declared, a dependency on the `testutil-server` of the same version is added.

On top of that, `testutil-client` is added to all client projects (i.e. projects that declare `spine.enableJava().client()` and `testlib` depdenency is added to all Java projects.

This PR also updates Spine version to `1.0.0-SNAPSHOT` to match that of [base](https://github.com/SpineEventEngine/base).