### PR TITLE
Eliminate Gradle boilerplate for pure JS projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,22 +100,3 @@ This configuration:
  - configures JS code generation from Protobuf.
  
 If only JS generation is configured, the Java code will not be generated (and the other way around).
-
-### Known issues of JS generation
-
-Since the `java` plugin is required in order to generate JS from Protobuf, the `compileJava` task is
-created. There may be a case when the build fails because the `compileJava` and `compileTestJava` 
-tasks cannot discover any `.java` files to compile. In such cases, disable those tasks:
-```gradle
-spine {
-    // Disable tasks inside the `spine` block in order to be sure that the `java` plugin is applied.
-    
-    compileJava.enabled = false
-    compileTestJava.enabled = false 
-}
-```
-
-This unlucky edge case affects only the Gradle projects which do not work with Java at all, only 
-with JavaScript. 
-
-This configuration will be automated in future releases.

--- a/license-report.md
+++ b/license-report.md
@@ -482,4 +482,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 14 17:55:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 20 14:48:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -482,4 +482,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 20 14:48:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 21 16:52:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
@@ -140,10 +140,9 @@ public final class Extension {
         toggleJavaTasks(false);
     }
 
-    private void toggleJavaTasks(boolean shouldEnable) {
-        this.javaEnabled = shouldEnable;
-        toggleCompileJavaTasks(shouldEnable);
-        toggleTransitiveProtos(shouldEnable);
+    private void toggleJavaTasks(boolean enabled) {
+        this.javaEnabled = enabled;
+        toggleCompileJavaTasks(enabled);
     }
 
     /**
@@ -167,12 +166,16 @@ public final class Extension {
      *
      * <p>If such tasks could not be found in the project, performs no action.
      */
-    private void toggleCompileJavaTasks(boolean shouldEnable) {
+    private void toggleCompileJavaTasks(boolean enabled) {
         TaskContainer tasks = project.getTasks();
-        Optional.ofNullable(tasks.findByPath(COMPILE_JAVA))
-                .ifPresent(task -> task.setEnabled(shouldEnable));
-        Optional.ofNullable(tasks.findByPath(COMPILE_TEST_JAVA))
-                .ifPresent(task -> task.setEnabled(shouldEnable));
+        Task compileJava = tasks.findByPath(COMPILE_JAVA);
+        Task compileTestJava = tasks.findByPath(COMPILE_TEST_JAVA);
+        if (compileJava != null) {
+            compileJava.setEnabled(enabled);
+        }
+        if (compileTestJava != null) {
+            compileTestJava.setEnabled(enabled);
+        }
     }
 
     /**

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
@@ -103,12 +103,12 @@ public final class Extension {
      */
     @CanIgnoreReturnValue
     public JavaExtension enableJava() {
-        disableTransitiveProtos();
         java.enableGeneration();
         String spineVersion = java.spineVersion();
         Artifact testlib = SpineDependency.testlib().ofVersion(spineVersion);
         java.dependant().depend(testImplementation, testlib.notation());
         toggleJavaTasks(true);
+        disableTransitiveProtos();
         return java;
     }
 
@@ -120,11 +120,11 @@ public final class Extension {
      */
     @CanIgnoreReturnValue
     public JavaScriptExtension enableJavaScript() {
-        disableTransitiveProtos();
         javaScript.enableGeneration();
         if (!this.javaEnabled) {
             toggleJavaTasks(false);
         }
+        disableTransitiveProtos();
         return javaScript;
     }
 

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
@@ -120,7 +120,7 @@ public final class Extension {
      */
     @CanIgnoreReturnValue
     public JavaScriptExtension enableJavaScript() {
-        disableJavaGeneration();
+        disableTransitiveProtos();
         javaScript.enableGeneration();
         if (!this.javaEnabled) {
             toggleJavaTasks(false);

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -29,8 +29,8 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.tools.gradle.ConfigurationName.COMPILE;
-import static io.spine.tools.gradle.ConfigurationName.TEST_IMPLEMENTATION;
+import static io.spine.tools.gradle.ConfigurationName.implementation;
+import static io.spine.tools.gradle.ConfigurationName.testImplementation;
 import static io.spine.tools.gradle.ProtobufDependencies.protobufLite;
 import static io.spine.tools.gradle.protoc.ProtocPlugin.Name.java;
 import static io.spine.tools.gradle.protoc.ProtocPlugin.called;
@@ -84,8 +84,8 @@ public final class JavaExtension extends CodeGenExtension {
      * dependencies to the project.
      */
     public void client() {
-        dependOn(SpineDependency.client(), COMPILE);
-        dependOn(SpineDependency.testUtilClient(), TEST_IMPLEMENTATION);
+        dependOn(SpineDependency.client(), implementation);
+        dependOn(SpineDependency.testUtilClient(), testImplementation);
     }
 
     /**
@@ -95,8 +95,8 @@ public final class JavaExtension extends CodeGenExtension {
      * dependencies to the project.
      */
     public void server() {
-        dependOn(SpineDependency.server(), COMPILE);
-        dependOn(SpineDependency.testUtilServer(), TEST_IMPLEMENTATION);
+        dependOn(SpineDependency.server(), implementation);
+        dependOn(SpineDependency.testUtilServer(), testImplementation);
     }
 
     private void dependOn(SpineDependency module, ConfigurationName configurationName) {

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.tools.gradle.ProtobufDependencies.protobufLite;
 import static io.spine.tools.gradle.TaskName.generateValidatingBuilders;
-import static io.spine.tools.gradle.bootstrap.Extension.COMPILE_JAVA;
 import static io.spine.tools.gradle.bootstrap.given.ExtensionTestEnv.GRPC_DEPENDENCY;
 import static io.spine.tools.gradle.bootstrap.given.ExtensionTestEnv.addExt;
 import static io.spine.tools.gradle.bootstrap.given.ExtensionTestEnv.spineVersion;
@@ -259,30 +258,6 @@ class ExtensionTest {
             assertTrue(codegen.getProtobuf());
             codegen.setProtobuf(false);
             assertFalse(codegen.getProtobuf());
-        }
-
-        @Test
-        @DisplayName("not create a `compileJava` task for JavaScript-only projects")
-        void notCreateCompileJava() {
-            extension.enableJavaScript();
-
-            assertThat(project.getTasks().findByPath(COMPILE_JAVA)).isNull();
-        }
-
-        @Test
-        @DisplayName("enable `compileJava` task for mixed projects")
-        void enableCompileJava() {
-            extension.enableJavaScript();
-            extension.enableJava();
-
-            assertThat(project.getTasks().findByPath(COMPILE_JAVA).getEnabled()).isTrue();
-        }
-
-        @Test
-        @DisplayName("disable `compilerJava` for projects that used to be mixed")
-        void disableCompileJava() {
-            extension.enableJavaScript();
-
         }
 
         private String serverDependency() {

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
@@ -50,6 +50,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.tools.gradle.ProtobufDependencies.protobufLite;
 import static io.spine.tools.gradle.TaskName.generateValidatingBuilders;
+import static io.spine.tools.gradle.bootstrap.Extension.COMPILE_JAVA;
 import static io.spine.tools.gradle.bootstrap.given.ExtensionTestEnv.GRPC_DEPENDENCY;
 import static io.spine.tools.gradle.bootstrap.given.ExtensionTestEnv.addExt;
 import static io.spine.tools.gradle.bootstrap.given.ExtensionTestEnv.spineVersion;
@@ -258,6 +259,30 @@ class ExtensionTest {
             assertTrue(codegen.getProtobuf());
             codegen.setProtobuf(false);
             assertFalse(codegen.getProtobuf());
+        }
+
+        @Test
+        @DisplayName("not create a `compileJava` task for JavaScript-only projects")
+        void notCreateCompileJava() {
+            extension.enableJavaScript();
+
+            assertThat(project.getTasks().findByPath(COMPILE_JAVA)).isNull();
+        }
+
+        @Test
+        @DisplayName("enable `compileJava` task for mixed projects")
+        void enableCompileJava() {
+            extension.enableJavaScript();
+            extension.enableJava();
+
+            assertThat(project.getTasks().findByPath(COMPILE_JAVA).getEnabled()).isTrue();
+        }
+
+        @Test
+        @DisplayName("disable `compilerJava` for projects that used to be mixed")
+        void disableCompileJava() {
+            extension.enableJavaScript();
+
         }
 
         private String serverDependency() {

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
@@ -99,7 +99,7 @@ class SpineBootstrapPluginTest {
 
         Collection<String> packageContents = generatedClassFileNames();
         IterableSubject assertPackageContents = assertThat(packageContents);
-        assertPackageContents.containsAllOf("LunaParkProto.class",
+        assertPackageContents.containsAtLeast("LunaParkProto.class",
                                             "RollerCoaster.class",
                                             "Wagon.class",
                                             "Altitude.class");
@@ -117,7 +117,7 @@ class SpineBootstrapPluginTest {
 
         Collection<String> packageContents = generatedClassFileNames();
         IterableSubject assertPackageContents = assertThat(packageContents);
-        assertPackageContents.containsAllOf("RollerCoasterVBuilder.class",
+        assertPackageContents.containsAtLeast("RollerCoasterVBuilder.class",
                                             "WagonVBuilder.class",
                                             "AltitudeVBuilder.class");
     }
@@ -130,7 +130,18 @@ class SpineBootstrapPluginTest {
         project.executeTask(build);
 
         Collection<String> jsFileNames = generatedJsFileNames();
-        assertThat(jsFileNames).containsExactly("roller_coaster_pb.js");
+        assertThat(jsFileNames).contains("roller_coaster_pb.js");
+    }
+
+    @Test
+    @DisplayName("generate an `index.js` file")
+    void generateIndexJs(){
+        configureJsGeneration();
+        GradleProject project = this.project.build();
+        project.executeTask(build);
+
+        Collection<String> jsFileNames = generatedJsFileNames();
+        assertThat(jsFileNames).contains("index.js");
     }
 
     @Test
@@ -170,7 +181,7 @@ class SpineBootstrapPluginTest {
         GradleProject project = this.project.build();
         project.executeTask(build);
         assertThat(generatedClassFileNames())
-                .containsAllOf("OrderServiceGrpc.class",
+                .containsAtLeast("OrderServiceGrpc.class",
                                "OrderServiceGrpc$OrderServiceStub.class",
                                "OrderServiceGrpc$OrderServiceImplBase.class");
     }
@@ -340,10 +351,7 @@ class SpineBootstrapPluginTest {
     }
 
     private Collection<String> generatedJsFileNames() {
-        Path compiledJsFiles = projectDir.resolve("build")
-                                         .resolve("generated")
-                                         .resolve("source")
-                                         .resolve("proto")
+        Path compiledJsFiles = projectDir.resolve("generated")
                                          .resolve("main")
                                          .resolve("js");
         File compiledJsDir = compiledJsFiles.toFile();

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
@@ -23,6 +23,7 @@ package io.spine.tools.gradle.bootstrap.func;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.truth.IterableSubject;
+import io.spine.tools.gradle.TaskName;
 import io.spine.tools.gradle.testing.GradleProject;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.BeforeEach;
@@ -100,9 +101,9 @@ class SpineBootstrapPluginTest {
         Collection<String> packageContents = generatedClassFileNames();
         IterableSubject assertPackageContents = assertThat(packageContents);
         assertPackageContents.containsAtLeast("LunaParkProto.class",
-                                            "RollerCoaster.class",
-                                            "Wagon.class",
-                                            "Altitude.class");
+                                              "RollerCoaster.class",
+                                              "Wagon.class",
+                                              "Altitude.class");
     }
 
     @Test
@@ -118,8 +119,8 @@ class SpineBootstrapPluginTest {
         Collection<String> packageContents = generatedClassFileNames();
         IterableSubject assertPackageContents = assertThat(packageContents);
         assertPackageContents.containsAtLeast("RollerCoasterVBuilder.class",
-                                            "WagonVBuilder.class",
-                                            "AltitudeVBuilder.class");
+                                              "WagonVBuilder.class",
+                                              "AltitudeVBuilder.class");
     }
 
     @Test
@@ -135,7 +136,7 @@ class SpineBootstrapPluginTest {
 
     @Test
     @DisplayName("generate an `index.js` file")
-    void generateIndexJs(){
+    void generateIndexJs() {
         configureJsGeneration();
         GradleProject project = this.project.build();
         project.executeTask(build);
@@ -145,13 +146,25 @@ class SpineBootstrapPluginTest {
     }
 
     @Test
+    @DisplayName("not generate transitive Spine dependencies for pure JS projects")
+    void skipTransitiveProtos() {
+        configureJsGeneration();
+        GradleProject project = this.project.build();
+        project.executeTask(TaskName.build);
+
+        Collection<String> jsFileNames = generatedJsFileNames();
+        assertThat(jsFileNames).doesNotContain("any_pb.js");
+    }
+
+    @Test
     @DisplayName("apply 'spine-proto-js-plugin'")
     void applyJsPlugin() {
         configureJsGeneration();
         GradleProject project = this.project.build();
         BuildResult result = project.executeTask(build);
 
-        assertThat(result.task(generateJsonParsers.path()).getOutcome()).isEqualTo(SUCCESS);
+        assertThat(result.task(generateJsonParsers.path())
+                         .getOutcome()).isEqualTo(SUCCESS);
     }
 
     @Test
@@ -182,8 +195,8 @@ class SpineBootstrapPluginTest {
         project.executeTask(build);
         assertThat(generatedClassFileNames())
                 .containsAtLeast("OrderServiceGrpc.class",
-                               "OrderServiceGrpc$OrderServiceStub.class",
-                               "OrderServiceGrpc$OrderServiceImplBase.class");
+                                 "OrderServiceGrpc$OrderServiceStub.class",
+                                 "OrderServiceGrpc$OrderServiceImplBase.class");
     }
 
     @Test

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
@@ -55,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SpineBootstrapPluginTest {
 
     private static final String ADDITIONAL_CONFIG_SCRIPT = "config.gradle";
+    private static final String TRANSITIVE_JS_DEPENDENCY = "any_pb.js";
 
     private GradleProject.Builder project;
     private Path projectDir;
@@ -153,7 +154,18 @@ class SpineBootstrapPluginTest {
         project.executeTask(TaskName.build);
 
         Collection<String> jsFileNames = generatedJsFileNames();
-        assertThat(jsFileNames).doesNotContain("any_pb.js");
+        assertThat(jsFileNames).doesNotContain(TRANSITIVE_JS_DEPENDENCY);
+    }
+
+    @Test
+    @DisplayName("not generate transitive Spine dependencies for mixed projects")
+    void skipTransitiveProtosForMixed(){
+        configureJsGeneration();
+        configureJavaGeneration();
+        GradleProject project = this.project.build();
+        project.executeTask(build);
+        assertThat(generatedJsFileNames()).doesNotContain(TRANSITIVE_JS_DEPENDENCY);
+        assertThat(generatedClassFileNames()).doesNotContain("Any.class");
     }
 
     @Test

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
@@ -159,9 +159,8 @@ class SpineBootstrapPluginTest {
 
     @Test
     @DisplayName("not generate transitive Spine dependencies for mixed projects")
-    void skipTransitiveProtosForMixed(){
-        configureJsGeneration();
-        configureJavaGeneration();
+    void skipTransitiveProtosForMixed() {
+        configureJavaAndJs();
         GradleProject project = this.project.build();
         project.executeTask(build);
         assertThat(generatedJsFileNames()).doesNotContain(TRANSITIVE_JS_DEPENDENCY);
@@ -261,6 +260,11 @@ class SpineBootstrapPluginTest {
         writeConfigGradle("spine.enableJava()");
     }
 
+    private void configureJavaAndJs() {
+        writeConfigGradle("spine.enableJava()",
+                          "spine.enableJavaScript()");
+    }
+
     private void configureJsGeneration() {
         writeConfigGradle(
                 "spine.enableJavaScript()",
@@ -301,7 +305,7 @@ class SpineBootstrapPluginTest {
     }
 
     @SuppressWarnings("DuplicateStringLiteralInspection")
-        // Part of the file contents may be duplicated.
+    // Part of the file contents may be duplicated.
     private void configureJavaAndGrpcWithoutGen() {
         writeConfigGradle(
                 "spine.enableJava {",
@@ -313,7 +317,7 @@ class SpineBootstrapPluginTest {
     }
 
     @SuppressWarnings("DuplicateStringLiteralInspection")
-        // Part of the file contents may be duplicated.
+    // Part of the file contents may be duplicated.
     private void configureJavaWithoutProtoOrSpine() {
         writeConfigGradle(
                 "spine.enableJava {",


### PR DESCRIPTION
This PR, together with https://github.com/SpineEventEngine/base/pull/419, fixes https://github.com/SpineEventEngine/bootstrap/issues/16.

Before, pure JavaScript projects, i.e projects that only declare `spine.enableJavaScript()`, required a lot of boilerplate, namely:
* exclusion of transitive `protobuf` dependencies in the `configurations` block. Example:
```groovy
configurations {
    protobuf.exclude group: 'io.spine', module: 'spine-base'
    protobuf.exclude group: 'io.spine', module: 'spine-core'
    protobuf.exclude group: 'io.spine', module: 'spine-client'
    protobuf.exclude group: 'com.google.protobuf'
}
```
* `protoc` plugin configurations, such as whether the descriptor set is to be generated, the location of the descriptor set, etc. Example: 
```groovy
protobuf {
    generatedFilesBaseDir = compiledProto
    protoc {
        artifact = deps.build.protoc
    }
    generateProtoTasks {
        all().each { final task ->
            task.plugins {
                task.generateDescriptorSet = false
            }
            task.builtins {
                remove java
                js {
                    option "import_style=commonjs"
                }
                task.generateDescriptorSet = true
                final def testClassifier = task.sourceSet.name == "test" ? "_test" : ""
                final def descriptorName = "${project.group}_${project.name}_${project.version}${testClassifier}.desc"
                task.descriptorSetOptions.path = "${projectDir}/build/descriptors/${task.sourceSet.name}/${descriptorName}"
            }
            compileProtoToJs.dependsOn task
        }
    }
}
```
* disabling `compileJava` and `compileTestJava` tasks.