### PR TITLE
Pure model modules

### DIFF
--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
@@ -131,6 +131,12 @@ public final class Extension {
         return javaScript;
     }
 
+    /**
+     * Marks this project as a project that contains the Protobuf model definition.
+     *
+     * <p>Enables the {@code protobuf} and {@code java} plugins. Also adds the generated source
+     * sets.
+     */
     public void assembleModel() {
         this.modelExtension.enableGeneration();
     }

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
@@ -59,12 +59,15 @@ public final class Extension {
 
     private final JavaExtension java;
     private final JavaScriptExtension javaScript;
+    private final ModelExtension modelExtension;
+
     private final Project project;
     private boolean javaEnabled = false;
 
     private Extension(Builder builder) {
         this.java = builder.buildJavaExtension();
         this.javaScript = builder.buildJavaScriptExtension();
+        this.modelExtension = builder.buildModelExtension();
         this.project = builder.project;
     }
 
@@ -126,6 +129,10 @@ public final class Extension {
         }
         disableTransitiveProtos();
         return javaScript;
+    }
+
+    public void assembleModel() {
+        this.modelExtension.enableGeneration();
     }
 
     /**
@@ -246,6 +253,18 @@ public final class Extension {
                     .setProtobufGenerator(generator)
                     .build();
             return javaScriptExtension;
+        }
+
+        private ModelExtension buildModelExtension() {
+            ModelExtension modelExtension = ModelExtension
+                    .newBuilder()
+                    .setProject(project)
+                    .setDependant(dependencyTarget)
+                    .setPluginTarget(pluginTarget)
+                    .setProtobufGenerator(generator)
+                    .setSourceSuperset(layout)
+                    .build();
+            return modelExtension;
         }
 
         /**

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/ModelExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/ModelExtension.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gradle.bootstrap;
+
+import io.spine.tools.gradle.GeneratedSourceRoot;
+import io.spine.tools.gradle.project.SourceSuperset;
+import io.spine.tools.gradle.protoc.ProtocPlugin;
+import org.gradle.api.Project;
+
+import static io.spine.tools.gradle.protoc.ProtocPlugin.Name.java;
+
+/** An extension which declares a module as one that contains the Protobuf model definition. */
+public class ModelExtension extends CodeGenExtension {
+
+    private final Project project;
+    private final SourceSuperset sourceSuperset;
+
+    private ModelExtension(Builder builder) {
+        super(builder);
+        this.project = builder.project();
+        this.sourceSuperset = builder.sourceSuperset;
+    }
+
+    /** Obtains a new builder of {@code ModelExtension}s. */
+    static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * Adds a Gradle source set that contains the Protobuf files that define the model.
+     */
+    public void addSourceSets() {
+        GeneratedSourceRoot sourceRoot = GeneratedSourceRoot.of(project);
+        sourceSuperset.register(sourceRoot);
+    }
+
+    /** Builer of {@code ModelExtension}s. */
+    static final class Builder extends CodeGenExtension.Builder<ModelExtension, Builder> {
+
+        private SourceSuperset sourceSuperset;
+
+        private Builder() {
+            super(ProtocPlugin.called(java));
+        }
+
+        Builder setSourceSuperset(SourceSuperset sourceSuperset) {
+            this.sourceSuperset = sourceSuperset;
+            return this;
+        }
+
+        @Override
+        Builder self() {
+            return this;
+        }
+
+        @Override
+        ModelExtension doBuild() {
+            return new ModelExtension(this);
+        }
+    }
+
+}

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/ModelExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/ModelExtension.java
@@ -28,7 +28,9 @@ import org.gradle.api.Project;
 
 import static io.spine.tools.gradle.protoc.ProtocPlugin.Name.java;
 
-/** An extension which declares a module as one that contains the Protobuf model definition. */
+/**
+ * An extension which declares a module as one that contains the Protobuf model definition.
+ */
 public final class ModelExtension extends CodeGenExtension {
 
     private final Project project;
@@ -59,7 +61,9 @@ public final class ModelExtension extends CodeGenExtension {
         sourceSuperset.register(GeneratedSourceRoot.of(project));
     }
 
-    /** Builder of {@code ModelExtension}s. */
+    /**
+     * Builder of {@code ModelExtension}s.
+     */
     static final class Builder extends CodeGenExtension.Builder<ModelExtension, Builder> {
 
         private SourceSuperset sourceSuperset;
@@ -83,5 +87,4 @@ public final class ModelExtension extends CodeGenExtension {
             return new ModelExtension(this);
         }
     }
-
 }

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/ModelExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/ModelExtension.java
@@ -29,7 +29,7 @@ import org.gradle.api.Project;
 import static io.spine.tools.gradle.protoc.ProtocPlugin.Name.java;
 
 /** An extension which declares a module as one that contains the Protobuf model definition. */
-public class ModelExtension extends CodeGenExtension {
+public final class ModelExtension extends CodeGenExtension {
 
     private final Project project;
     private final SourceSuperset sourceSuperset;

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/ModelExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/ModelExtension.java
@@ -20,6 +20,7 @@
 
 package io.spine.tools.gradle.bootstrap;
 
+import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import io.spine.tools.gradle.GeneratedSourceRoot;
 import io.spine.tools.gradle.project.SourceSuperset;
 import io.spine.tools.gradle.protoc.ProtocPlugin;
@@ -44,15 +45,21 @@ public class ModelExtension extends CodeGenExtension {
         return new Builder();
     }
 
+    @OverridingMethodsMustInvokeSuper
+    @Override
+    void enableGeneration() {
+        super.enableGeneration();
+        addSourceSets();
+    }
+
     /**
      * Adds a Gradle source set that contains the Protobuf files that define the model.
      */
-    public void addSourceSets() {
-        GeneratedSourceRoot sourceRoot = GeneratedSourceRoot.of(project);
-        sourceSuperset.register(sourceRoot);
+    private void addSourceSets() {
+        sourceSuperset.register(GeneratedSourceRoot.of(project));
     }
 
-    /** Builer of {@code ModelExtension}s. */
+    /** Builder of {@code ModelExtension}s. */
     static final class Builder extends CodeGenExtension.Builder<ModelExtension, Builder> {
 
         private SourceSuperset sourceSuperset;

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
@@ -250,6 +250,21 @@ class ExtensionTest {
             assertThat(dependencyTarget.dependencies()).contains(GRPC_DEPENDENCY);
         }
 
+        /** Applying {@code Java} plugin is necessary to apply the {@code protobuf} plugin. */
+        @Test
+        @DisplayName("apply Java plugin to projects that contain only the model definition")
+        void javaPluginToModelProjects() {
+            extension.assembleModel();
+            assertApplied(JavaPlugin.class);
+        }
+
+        @Test
+        @DisplayName("apply Protobuf plugin to projects that contain only the model definition")
+        void protobufPluginToModelProjects() {
+            extension.assembleModel();
+            assertApplied(ProtobufPlugin.class);
+        }
+
         @Test
         @DisplayName("disable Java code generation in Java projects")
         void disableCodegen() {

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
@@ -252,6 +252,16 @@ class SpineBootstrapPluginTest {
         assertFalse(exists(compiledClasses));
     }
 
+    @Test
+    @DisplayName("generate no code for projects that only define the model")
+    void noJsForModelProjects() {
+        configureModelProject();
+        GradleProject project = this.project.build();
+        project.executeTask(build);
+
+        assertThat(generatedFiles().toFile().exists()).isFalse();
+    }
+
     private void noAdditionalConfig() {
         writeConfigGradle();
     }
@@ -328,6 +338,10 @@ class SpineBootstrapPluginTest {
                 "}");
     }
 
+    private void configureModelProject() {
+        writeConfigGradle("spine.assembleModel()");
+    }
+
     @SuppressWarnings("CheckReturnValue")
     private void writeConfigGradle(String... lines) {
         project.createFile(ADDITIONAL_CONFIG_SCRIPT, ImmutableSet.copyOf(lines));
@@ -371,6 +385,18 @@ class SpineBootstrapPluginTest {
         return compiledClasses;
     }
 
+    private Path generatedFiles() {
+        Path generated = projectDir.resolve("generated");
+        return generated;
+    }
+
+    private Path generatedJsFiles() {
+        Path compiledJsFiles = generatedFiles()
+                .resolve("main")
+                .resolve("js");
+        return compiledJsFiles;
+    }
+
     private static Path resolveClassesInPackage(Path compiledJavaClasses) {
         return compiledJavaClasses.resolve("io")
                                   .resolve("spine")
@@ -380,9 +406,7 @@ class SpineBootstrapPluginTest {
     }
 
     private Collection<String> generatedJsFileNames() {
-        Path compiledJsFiles = projectDir.resolve("generated")
-                                         .resolve("main")
-                                         .resolve("js");
+        Path compiledJsFiles = generatedJsFiles();
         File compiledJsDir = compiledJsFiles.toFile();
         assertTrue(compiledJsDir.exists());
         assertTrue(compiledJsDir.isDirectory());


### PR DESCRIPTION
This PR removes the necessity to call `enableJava()` in pure Protobuf projects.

Before, projects that contained the model definition in Protobuf had to have the `enableJava()` method called, because it was the only way to enable the `java` plugin that is necessary for the `protobuf` plugin to work.

Now, a separate `assembleModel()` exists to remove this ambiguity.