### PR TITLE
Update version to 0.15.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Gradle plugin for bootstrapping projects built with Spine.
 In order to apply the plugin to a Gradle project, in `build.gralde` add the following config:
 ```gradle
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '0.15.6'
+    id 'io.spine.tools.gradle.bootstrap' version '0.15.8'
 }
 ```
 

--- a/gradle/plugin.gradle
+++ b/gradle/plugin.gradle
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-ext.pluginVersion = '0.15.7'
+ext.pluginVersion = '0.15.8'
 
 project.gradlePlugin {
     it.plugins {

--- a/plugin/src/test/resources/build.gradle
+++ b/plugin/src/test/resources/build.gradle
@@ -19,7 +19,7 @@
  */
 
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '0.15.6'
+    id 'io.spine.tools.gradle.bootstrap' version '0.15.8'
 }
 
 // This script file is created at a test runtime by the `GradleProject`.


### PR DESCRIPTION
Current version — `0.15.7` — is published and deleted from the plugin portal. A plugin cannot be re-published with the same version. So, we propagate the version further.