### PR TITLE
Add `time` and `testutil-time` dependencies automatically

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -488,4 +488,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 30 14:26:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 30 19:45:35 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/CodeGenExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/CodeGenExtension.java
@@ -33,6 +33,7 @@ import org.gradle.api.Project;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.tools.gradle.config.SpineDependency.base;
+import static io.spine.tools.gradle.config.SpineDependency.time;
 
 /**
  * A part of the {@link Extension spine} extension which configures certain code generation tasks.
@@ -71,6 +72,7 @@ abstract class CodeGenExtension implements Logging {
         pluginTarget.applyJavaPlugin();
         String spineVersion = artifactSnapshot.spineVersion();
         dependant.compile(base().ofVersion(spineVersion));
+        dependant.compile(time().ofVersion(spineVersion));
         if (codeGenJob != null) {
             pluginTarget.applyProtobufPlugin();
             protobufGenerator.enableBuiltIn(codeGenJob);

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
@@ -22,10 +22,8 @@ package io.spine.tools.gradle.bootstrap;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import groovy.lang.Closure;
-import io.spine.tools.gradle.Artifact;
 import io.spine.tools.gradle.ConfigurationName;
 import io.spine.tools.gradle.config.ArtifactSnapshot;
-import io.spine.tools.gradle.config.SpineDependency;
 import io.spine.tools.gradle.project.Dependant;
 import io.spine.tools.gradle.project.PluginTarget;
 import io.spine.tools.gradle.project.SourceSuperset;
@@ -38,7 +36,6 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.tasks.TaskContainer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.tools.gradle.ConfigurationName.testImplementation;
 import static io.spine.tools.gradle.TaskName.compileJava;
 import static io.spine.tools.gradle.TaskName.compileTestJava;
 import static io.spine.tools.groovy.ConsumerClosure.closure;
@@ -124,8 +121,6 @@ public final class Extension {
     @CanIgnoreReturnValue
     public JavaExtension enableJava() {
         java.enableGeneration();
-        Artifact testlib = SpineDependency.testlib().ofVersion(version());
-        java.dependant().depend(testImplementation, testlib.notation());
         toggleJavaTasks(true);
         disableTransitiveProtos();
         return java;

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -60,6 +60,11 @@ public final class JavaExtension extends CodeGenExtension {
     @Override
     void enableGeneration() {
         super.enableGeneration();
+
+        dependOn(SpineDependency.time(), implementation);
+        dependOn(SpineDependency.testUtilTime(), testImplementation);
+        dependOn(SpineDependency.testlib(), testImplementation);
+
         pluginTarget().applyModelCompiler();
         pluginTarget().apply(SpinePluginScripts.modelCompilerConfig());
         addSourceSets();

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -61,9 +61,8 @@ public final class JavaExtension extends CodeGenExtension {
     void enableGeneration() {
         super.enableGeneration();
 
-        dependOn(SpineDependency.time(), implementation);
-        dependOn(SpineDependency.testUtilTime(), testImplementation);
         dependOn(SpineDependency.testlib(), testImplementation);
+        dependOn(SpineDependency.testUtilTime(), testImplementation);
 
         pluginTarget().applyModelCompiler();
         pluginTarget().apply(SpinePluginScripts.modelCompilerConfig());

--- a/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
@@ -30,11 +30,13 @@ public final class SpineDependency implements Dependency {
     private static final String SPINE_PREFIX = "spine-";
 
     private static final SpineDependency BASE = new SpineDependency("base");
+    private static final SpineDependency TIME = new SpineDependency("time");
     private static final SpineDependency CLIENT = new SpineDependency("client");
     private static final SpineDependency SERVER = new SpineDependency("server");
     private static final SpineDependency TEST_UTIL_SERVER = new SpineDependency("testutil-server");
     private static final SpineDependency TEST_UTIL_CLIENT = new SpineDependency("testutil-client");
     private static final SpineDependency TESTLIB = new SpineDependency("testlib");
+    private static final SpineDependency TEST_UTIL_TIME = new SpineDependency("testutil-time");
 
     private final String shortName;
 
@@ -47,6 +49,13 @@ public final class SpineDependency implements Dependency {
      */
     public static SpineDependency base() {
         return BASE;
+    }
+
+    /**
+     * Obtains a dependency on the {@code io.spine:spine-base} module.
+     */
+    public static SpineDependency time() {
+        return TIME;
     }
 
     /**
@@ -77,8 +86,18 @@ public final class SpineDependency implements Dependency {
         return TEST_UTIL_CLIENT;
     }
 
+    /**
+     * Obtains a dependency on the {@code io.spine:testlib} module.
+     */
     public static SpineDependency testlib() {
         return TESTLIB;
+    }
+
+    /**
+     * Obtains a dependency on the {@code io.spine:testutil-time} module.
+     */
+    public static SpineDependency testUtilTime() {
+        return TEST_UTIL_TIME;
     }
 
     @Override

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
@@ -96,6 +96,54 @@ class ExtensionTest {
     class ApplyPlugins {
 
         @Test
+        @DisplayName("add `base` dependency to a Java project")
+        void addBaseDependencyToJava() {
+            extension.enableJava();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(baseDependency());
+        }
+
+        @Test
+        @DisplayName("add `base` dependency to a JS project")
+        void addBaseDependencyToJs() {
+            extension.enableJavaScript();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(baseDependency());
+        }
+
+        @Test
+        @DisplayName("add `base` dependency to a model-only project")
+        void addBaseDependencyToModel() {
+            extension.assembleModel();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(baseDependency());
+        }
+
+        @Test
+        @DisplayName("add `time` dependency to a Java project")
+        void addTimeDependencyToJava() {
+            extension.enableJava();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(timeDependency());
+        }
+
+        @Test
+        @DisplayName("add `time` dependency to a JS project")
+        void addTimeDependencyToJs() {
+            extension.enableJavaScript();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(timeDependency());
+        }
+
+        @Test
+        @DisplayName("add `time` dependency to a model-only project")
+        void addTimeDependencyToModel() {
+            extension.assembleModel();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(timeDependency());
+        }
+
+        @Test
         @DisplayName("apply Model Compiler plugin to a Java project")
         void applyModelCompiler() {
             extension.enableJava();
@@ -118,6 +166,14 @@ class ExtensionTest {
             extension.enableJava();
             assertThat(dependencyTarget.dependencies())
                     .contains(testlibDependency());
+        }
+
+        @Test
+        @DisplayName("add `testutil-time` dependency to a Java project")
+        void addTestUtilTimeDependecy() {
+            extension.enableJava();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(testUtilTimeDependency());
         }
 
         @Test
@@ -154,6 +210,15 @@ class ExtensionTest {
 
             assertThat(dependencyTarget.dependencies())
                     .doesNotContain(testlibDependency());
+        }
+
+        @Test
+        @DisplayName("not add a `testutil-time` dependency to a JS project")
+        void noTestUtilTimeForJs() {
+            extension.enableJavaScript();
+
+            assertThat(dependencyTarget.dependencies())
+                    .doesNotContain(testUtilTimeDependency());
         }
 
         @Test
@@ -278,6 +343,14 @@ class ExtensionTest {
             assertFalse(codegen.getProtobuf());
         }
 
+        private String baseDependency() {
+            return "io.spine:spine-base:" + spineVersion;
+        }
+
+        private String timeDependency() {
+            return "io.spine:spine-time:" + spineVersion;
+        }
+
         private String serverDependency() {
             return "io.spine:spine-server:" + spineVersion;
         }
@@ -296,6 +369,10 @@ class ExtensionTest {
 
         private String testlibDependency() {
             return "io.spine:spine-testlib:" + spineVersion;
+        }
+
+        private String testUtilTimeDependency() {
+            return "io.spine:spine-testutil-time:" + spineVersion;
         }
 
         private void assertApplied(Class<? extends Plugin<? extends Project>> pluginClass) {


### PR DESCRIPTION
This PR adds an automatic addition of `time` and `testutil-time` dependencies to the projects where bootstrap is applied.

The `testutil-time` dependency is added only to Java projects (`spine.enableJava()`), while the `time` dependency is added to all project types (as it exposes Proto types, which can be used in projects based on any language, i.e. JS).

The fix is applied to the current plugin version, which is `1.0.2`.