### PR TITLE
Release `1.0.3`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.0.2`
+# Dependencies of `io.spine.tools:spine-plugin:1.0.3`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -38,7 +38,7 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.guava **Name:** guava **Version:** 28.0-jre
+1. **Group:** com.google.guava **Name:** guava **Version:** 28.1-jre
      * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -101,7 +101,7 @@
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.18
      * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -214,12 +214,12 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.guava **Name:** guava **Version:** 28.0-jre
+1. **Group:** com.google.guava **Name:** guava **Version:** 28.1-jre
      * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 28.0-jre
+1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 28.1-jre
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.guava **Name:** listenablefuture **Version:** 9999.0-empty-to-avoid-conflict-with-guava
@@ -357,7 +357,7 @@
      * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.18
      * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -488,4 +488,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 30 14:26:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 01 21:10:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -488,4 +488,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 30 14:26:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 30 19:45:35 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/CodeGenExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/CodeGenExtension.java
@@ -33,6 +33,7 @@ import org.gradle.api.Project;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.tools.gradle.config.SpineDependency.base;
+import static io.spine.tools.gradle.config.SpineDependency.time;
 
 /**
  * A part of the {@link Extension spine} extension which configures certain code generation tasks.
@@ -71,6 +72,7 @@ abstract class CodeGenExtension implements Logging {
         pluginTarget.applyJavaPlugin();
         String spineVersion = artifactSnapshot.spineVersion();
         dependant.compile(base().ofVersion(spineVersion));
+        dependant.compile(time().ofVersion(spineVersion));
         if (codeGenJob != null) {
             pluginTarget.applyProtobufPlugin();
             protobufGenerator.enableBuiltIn(codeGenJob);

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
@@ -22,10 +22,8 @@ package io.spine.tools.gradle.bootstrap;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import groovy.lang.Closure;
-import io.spine.tools.gradle.Artifact;
 import io.spine.tools.gradle.ConfigurationName;
 import io.spine.tools.gradle.config.ArtifactSnapshot;
-import io.spine.tools.gradle.config.SpineDependency;
 import io.spine.tools.gradle.project.Dependant;
 import io.spine.tools.gradle.project.PluginTarget;
 import io.spine.tools.gradle.project.SourceSuperset;
@@ -38,7 +36,6 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.tasks.TaskContainer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.tools.gradle.ConfigurationName.testImplementation;
 import static io.spine.tools.gradle.TaskName.compileJava;
 import static io.spine.tools.gradle.TaskName.compileTestJava;
 import static io.spine.tools.groovy.ConsumerClosure.closure;
@@ -124,8 +121,6 @@ public final class Extension {
     @CanIgnoreReturnValue
     public JavaExtension enableJava() {
         java.enableGeneration();
-        Artifact testlib = SpineDependency.testlib().ofVersion(version());
-        java.dependant().depend(testImplementation, testlib.notation());
         toggleJavaTasks(true);
         disableTransitiveProtos();
         return java;

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -60,10 +60,8 @@ public final class JavaExtension extends CodeGenExtension {
     @Override
     void enableGeneration() {
         super.enableGeneration();
-
         dependOn(SpineDependency.testlib(), testImplementation);
         dependOn(SpineDependency.testUtilTime(), testImplementation);
-
         pluginTarget().applyModelCompiler();
         pluginTarget().apply(SpinePluginScripts.modelCompilerConfig());
         addSourceSets();

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -60,6 +60,11 @@ public final class JavaExtension extends CodeGenExtension {
     @Override
     void enableGeneration() {
         super.enableGeneration();
+
+        dependOn(SpineDependency.time(), implementation);
+        dependOn(SpineDependency.testUtilTime(), testImplementation);
+        dependOn(SpineDependency.testlib(), testImplementation);
+
         pluginTarget().applyModelCompiler();
         pluginTarget().apply(SpinePluginScripts.modelCompilerConfig());
         addSourceSets();

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -61,9 +61,8 @@ public final class JavaExtension extends CodeGenExtension {
     void enableGeneration() {
         super.enableGeneration();
 
-        dependOn(SpineDependency.time(), implementation);
-        dependOn(SpineDependency.testUtilTime(), testImplementation);
         dependOn(SpineDependency.testlib(), testImplementation);
+        dependOn(SpineDependency.testUtilTime(), testImplementation);
 
         pluginTarget().applyModelCompiler();
         pluginTarget().apply(SpinePluginScripts.modelCompilerConfig());

--- a/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
@@ -30,11 +30,13 @@ public final class SpineDependency implements Dependency {
     private static final String SPINE_PREFIX = "spine-";
 
     private static final SpineDependency BASE = new SpineDependency("base");
+    private static final SpineDependency TIME = new SpineDependency("time");
     private static final SpineDependency CLIENT = new SpineDependency("client");
     private static final SpineDependency SERVER = new SpineDependency("server");
     private static final SpineDependency TEST_UTIL_SERVER = new SpineDependency("testutil-server");
     private static final SpineDependency TEST_UTIL_CLIENT = new SpineDependency("testutil-client");
     private static final SpineDependency TESTLIB = new SpineDependency("testlib");
+    private static final SpineDependency TEST_UTIL_TIME = new SpineDependency("testutil-time");
 
     private final String shortName;
 
@@ -47,6 +49,13 @@ public final class SpineDependency implements Dependency {
      */
     public static SpineDependency base() {
         return BASE;
+    }
+
+    /**
+     * Obtains a dependency on the {@code io.spine:spine-base} module.
+     */
+    public static SpineDependency time() {
+        return TIME;
     }
 
     /**
@@ -77,8 +86,18 @@ public final class SpineDependency implements Dependency {
         return TEST_UTIL_CLIENT;
     }
 
+    /**
+     * Obtains a dependency on the {@code io.spine:testlib} module.
+     */
     public static SpineDependency testlib() {
         return TESTLIB;
+    }
+
+    /**
+     * Obtains a dependency on the {@code io.spine:testutil-time} module.
+     */
+    public static SpineDependency testUtilTime() {
+        return TEST_UTIL_TIME;
     }
 
     @Override

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
@@ -96,6 +96,54 @@ class ExtensionTest {
     class ApplyPlugins {
 
         @Test
+        @DisplayName("add `base` dependency to a Java project")
+        void addBaseDependencyToJava() {
+            extension.enableJava();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(baseDependency());
+        }
+
+        @Test
+        @DisplayName("add `base` dependency to a JS project")
+        void addBaseDependencyToJs() {
+            extension.enableJavaScript();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(baseDependency());
+        }
+
+        @Test
+        @DisplayName("add `base` dependency to a model-only project")
+        void addBaseDependencyToModel() {
+            extension.assembleModel();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(baseDependency());
+        }
+
+        @Test
+        @DisplayName("add `time` dependency to a Java project")
+        void addTimeDependencyToJava() {
+            extension.enableJava();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(timeDependency());
+        }
+
+        @Test
+        @DisplayName("add `time` dependency to a JS project")
+        void addTimeDependencyToJs() {
+            extension.enableJavaScript();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(timeDependency());
+        }
+
+        @Test
+        @DisplayName("add `time` dependency to a model-only project")
+        void addTimeDependencyToModel() {
+            extension.assembleModel();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(timeDependency());
+        }
+
+        @Test
         @DisplayName("apply Model Compiler plugin to a Java project")
         void applyModelCompiler() {
             extension.enableJava();
@@ -118,6 +166,14 @@ class ExtensionTest {
             extension.enableJava();
             assertThat(dependencyTarget.dependencies())
                     .contains(testlibDependency());
+        }
+
+        @Test
+        @DisplayName("add `testutil-time` dependency to a Java project")
+        void addTestUtilTimeDependecy() {
+            extension.enableJava();
+            assertThat(dependencyTarget.dependencies())
+                    .contains(testUtilTimeDependency());
         }
 
         @Test
@@ -154,6 +210,15 @@ class ExtensionTest {
 
             assertThat(dependencyTarget.dependencies())
                     .doesNotContain(testlibDependency());
+        }
+
+        @Test
+        @DisplayName("not add a `testutil-time` dependency to a JS project")
+        void noTestUtilTimeForJs() {
+            extension.enableJavaScript();
+
+            assertThat(dependencyTarget.dependencies())
+                    .doesNotContain(testUtilTimeDependency());
         }
 
         @Test
@@ -278,6 +343,14 @@ class ExtensionTest {
             assertFalse(codegen.getProtobuf());
         }
 
+        private String baseDependency() {
+            return "io.spine:spine-base:" + spineVersion;
+        }
+
+        private String timeDependency() {
+            return "io.spine:spine-time:" + spineVersion;
+        }
+
         private String serverDependency() {
             return "io.spine:spine-server:" + spineVersion;
         }
@@ -296,6 +369,10 @@ class ExtensionTest {
 
         private String testlibDependency() {
             return "io.spine:spine-testlib:" + spineVersion;
+        }
+
+        private String testUtilTimeDependency() {
+            return "io.spine:spine-testutil-time:" + spineVersion;
         }
 
         private void assertApplied(Class<? extends Plugin<? extends Project>> pluginClass) {

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.0.2</version>
+<version>1.0.3</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -40,7 +40,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.guava</groupId>
     <artifactId>guava</artifactId>
-    <version>28.0-jre</version>
+    <version>28.1-jre</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -52,25 +52,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-js-plugin</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -82,7 +82,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-testlib</artifactId>
-    <version>28.0-jre</version>
+    <version>28.1-jre</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -106,13 +106,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -158,7 +158,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle
+++ b/version.gradle
@@ -29,7 +29,7 @@
  * already in the root directory.
  */
 
-final def SPINE_VERSION = '1.0.2'
+final def SPINE_VERSION = '1.0.3'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR updates the Spine versions used by this plugin to `1.0.3`.

Own version of the plugin is also set to `1.0.3`.