### PR TITLE
Synchronize the plugin version with the Spine version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Gradle plugin for bootstrapping projects built with Spine.
 In order to apply the plugin to a Gradle project, in `build.gralde` add the following config:
 ```gradle
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '1.0.2'
+    id 'io.spine.tools.gradle.bootstrap' version '1.0.3'
 }
 ```
 

--- a/gradle/plugin.gradle
+++ b/gradle/plugin.gradle
@@ -18,8 +18,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-ext.pluginVersion = '1.0.2'
-
 project.gradlePlugin {
     it.plugins {
         spineBootstrapPlugin {
@@ -39,17 +37,14 @@ project.pluginBundle {
     it.mavenCoordinates {
         groupId = 'io.spine.tools'
         artifactId = 'spine-bootstrap'
-        // Corresponds to the latest `web` version.
-        // Gradle Plugin portal does not allow to override published artifacts.
-        // Should be synchronized with the framework version as soon as 1.0.0-SNAPSHOT era is over.
-        version = project.pluginVersion
+        version = project.spineVersion
     }
 
     it.withDependencies { it.clear() }
 
     it.plugins {
         spineBootstrapPlugin {
-            version = project.pluginVersion
+            version = project.spineVersion
         }
     }
 }

--- a/license-report.md
+++ b/license-report.md
@@ -488,4 +488,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 21:10:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 02 18:15:44 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin/src/test/resources/build.gradle
+++ b/plugin/src/test/resources/build.gradle
@@ -19,7 +19,7 @@
  */
 
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '1.0.2'
+    id 'io.spine.tools.gradle.bootstrap' version '1.0.3'
 }
 
 // This script file is created at a test runtime by the `GradleProject`.


### PR DESCRIPTION
This PR synchronizes the `bootstrap` plugin version with the framework version and thus sets it to `1.0.3`.

In fact, the plugin version was always the same as the Spine version starting from `1.0.1`. 

This PR just removes the necessity to re-type it manually every time the version updates.
