### PR TITLE
Update version to `1.0.8-SNAPSHOT`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.0.3`
+# Dependencies of `io.spine.tools:spine-plugin:1.0.8-SNAPSHOT`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -488,4 +488,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 02 18:15:44 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 16:34:20 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.0.3</version>
+<version>1.0.8-SNAPSHOT</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -52,25 +52,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-js-plugin</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -106,13 +106,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -158,7 +158,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle
+++ b/version.gradle
@@ -29,7 +29,7 @@
  * already in the root directory.
  */
 
-final def SPINE_VERSION = '1.0.3'
+final def SPINE_VERSION = '1.0.8-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR publishes the plugin of version `1.0.8-SNAPSHOT`. Our users need their Spine dependencies to be upgraded to this version.