### PR TITLE
Larger heap size for Gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-org.gradle.jvmargs=-Xmx512m -XX:MaxPermSize=256m
+org.gradle.jvmargs=-Xmx1g -XX:MaxPermSize=256m

--- a/license-report.md
+++ b/license-report.md
@@ -488,4 +488,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Sep 06 16:34:20 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 17:20:59 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).


### PR DESCRIPTION
When publishing the plugin to the Gradle portal, we sometimes run out of memory.

Here is the error:
```
Publishing plugin io.spine.tools.gradle.bootstrap version 1.0.8-SNAPSHOT
Publishing artifact build/libs/plugin-1.0.8-SNAPSHOT-sources.jar
Publishing artifact build/libs/plugin-1.0.8-SNAPSHOT-javadoc.jar
Publishing artifact build/libs/plugin-1.0.8-SNAPSHOT.jar
> Task :plugin:publishPlugins FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':plugin:publishPlugins'.
> Java heap space
```

Not only does this prevent the plugin from being published, but also this leaves some kind of metadata in the Gradle repository, which means that we have to call the wonderful Gradle team to the rescue each time.

This PR advances the Gradle's JVM heap size to 1GB so that the plugin can fit.