### PR TITLE
1.5.8 minor version update

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -825,6 +825,7 @@
     <inspection_tool class="UnqualifiedInnerClassAccess" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="ignoreReferencesToLocalInnerClasses" value="true" />
     </inspection_tool>
+    <inspection_tool class="UnnecessaryLocalVariable" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Tests" level="WEAK WARNING" enabled="false" />

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -31,14 +31,17 @@ apply from: "$rootDir/gradle/func-test-env.gradle"
 apply from: "$rootDir/gradle/prepare-config-resources.gradle"
 
 dependencies {
-    implementation gradleApi()
-    implementation "io.spine.tools:spine-plugin-base:$spineVersion"
-    implementation "io.spine.tools:spine-model-compiler:$spineVersion"
-    implementation "io.spine.tools:spine-proto-js-plugin:$spineVersion"
-    implementation deps.build.gradlePlugins.protobuf
-
-    testImplementation "io.spine:spine-testlib:$spineVersion"
-    testImplementation "io.spine.tools:spine-plugin-testlib:$spineVersion"
+    implementation(
+            gradleApi(),
+            deps.build.gradlePlugins.protobuf,
+            "io.spine.tools:spine-plugin-base:$spineVersion",
+            "io.spine.tools:spine-model-compiler:$spineVersion",
+            "io.spine.tools:spine-proto-js-plugin:$spineVersion",
+    )
+    testImplementation(
+            "io.spine:spine-testlib:$spineVersion",
+            "io.spine.tools:spine-plugin-testlib:$spineVersion"
+    )
 }
 
 final targetResourceDir = "$buildDir/compiledResources/"

--- a/version.gradle
+++ b/version.gradle
@@ -29,7 +29,7 @@
  * already in the root directory.
  */
 
-final def SPINE_VERSION = '1.5.0'
+final def SPINE_VERSION = '1.5.8'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR advances the plugin to version `1.5.8` for being used in newer examples until `1.6.0` is out.