### PR TITLE
Publish plugin to the portal

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,13 +37,14 @@ apply(from = "$rootDir/version.gradle.kts")
 
 val spineVersion: String by extra
 val spineBaseVersion: String by extra
+val pluginVersion: String by extra
 
 allprojects {
     apply(from = "$rootDir/version.gradle.kts")
     apply(from = "$rootDir/config/gradle/dependencies.gradle")
 
     group = "io.spine.tools"
-    version = spineVersion
+    version = pluginVersion
 }
 
 subprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-org.gradle.jvmargs=-Xmx1g -XX:MaxPermSize=256m
+org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=512m

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -35,6 +35,7 @@ apply<IncrementGuard>()
 
 val spineVersion: String by extra
 val spineBaseVersion: String by extra
+val pluginVersion: String by extra
 
 dependencies {
     implementation(gradleApi())
@@ -78,14 +79,14 @@ pluginBundle {
     mavenCoordinates {
         groupId = "io.spine.tools"
         artifactId = "spine-bootstrap"
-        version = spineVersion
+        version = pluginVersion
     }
 
     withDependencies { clear() }
 
     plugins {
         named("spineBootstrapPlugin") {
-            version = spineVersion
+            version = pluginVersion
         }
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,3 +32,4 @@
 val spineBaseVersion: String by extra("1.5.12")
 val spineTimeVersion: String by extra("1.5.12")
 val spineVersion: String by extra("1.5.14")
+val pluginVersion: String by extra("1.5.15")


### PR DESCRIPTION
On a previous [attempt](https://travis-ci.com/github/SpineEventEngine/bootstrap/builds/169581755), the plugin failed to be published to the Gradle plugin portal due to a memory deficiency. This is presumably caused by the Kotlin runtime requiring more memory than Groovy runtime.

In an attempt to publish the plugin, we increase the memory limit for the Gradle JVM twofold.