### PR TITLE
Publish Gradle plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=1024m
+org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=1024m
 org.gradle.logging.level=info

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.5.19`
+# Dependencies of `io.spine.tools:spine-plugin:1.5.20`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -338,4 +338,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jun 18 14:55:44 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 18 16:21:50 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.5.19</version>
+<version>1.5.20</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
 val spineBaseVersion: String by extra("1.5.19")
 val spineTimeVersion: String by extra("1.5.12")
 val spineVersion: String by extra("1.5.14")
-val pluginVersion: String by extra("1.5.19")
+val pluginVersion: String by extra("1.5.20")


### PR DESCRIPTION
This is a second attempt to publish a new version of the plugin (see PR #54). The first attempt failed with `Java heap space` error.