### PR TITLE
Publish updated Spine libraries. Take 2

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.5.22`
+# Dependencies of `io.spine.tools:spine-plugin:1.5.23`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -337,4 +337,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 19 16:38:41 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 20 22:52:41 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.5.22</version>
+<version>1.5.23</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
 val spineBaseVersion: String by extra("1.5.19")
 val spineTimeVersion: String by extra("1.5.19")
 val spineVersion: String by extra("1.5.20")
-val pluginVersion: String by extra("1.5.22")
+val pluginVersion: String by extra("1.5.23")


### PR DESCRIPTION
The PR is the next attempt to successfully publish plugin with the latest Spine libraries. (see #58).

Also, we are trying the updated publishing with the heap memory set directly for the publishing task. (see https://github.com/SpineEventEngine/config/pull/126).