### PR TITLE
Update model compiler

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,7 +27,7 @@ repositories {
     jcenter()
 }
 
-val jacksonVersion = "2.11.0"
+val jacksonVersion = "2.11.2"
 
 dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")

--- a/buildSrc/src/main/kotlin/bootstrap-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/bootstrap-plugin.gradle.kts
@@ -1,3 +1,8 @@
+import Bootstrap_plugin_gradle.Nodes.findAll
+import Bootstrap_plugin_gradle.Nodes.findFirst
+import org.w3c.dom.Node
+import org.w3c.dom.NodeList
+
 /*
  * Copyright 2020, TeamDev. All rights reserved.
  *
@@ -30,6 +35,57 @@ gradlePlugin {
             implementationClass = "io.spine.tools.gradle.bootstrap.BootstrapPlugin"
             displayName = "Spine Bootstrap"
             description = "Prepares a Gradle project for development on Spine."
+        }
+    }
+}
+
+/**
+ * Utilities for working with DOM nodes.
+ */
+object Nodes {
+
+    /**
+     * Finds the first node with the given name in this `NodeList`.
+     *
+     * @return a node with the given name or `null` if this list does not contain such a node
+     */
+    fun NodeList.findFirst(name: String): Node? {
+        for (i in (0 until length)) {
+            val child = item(i)
+            if (child.nodeName == name) {
+                return child
+            }
+        }
+        return null
+    }
+
+    /**
+     * Finds all the nodes with the given name in this `NodeList`.
+     *
+     * @return a list of all the nodes with a given name; an empty list if this `NodeList` does not
+     * contain such nodes
+     */
+    fun NodeList.findAll(name: String): List<Node> {
+        val nodes = mutableListOf<Node>()
+        for (i in (0 until length)) {
+            val child = item(i)
+            if (child.nodeName == name) {
+                nodes.add(child)
+            }
+        }
+        return nodes
+    }
+}
+
+project.afterEvaluate {
+    tasks.withType(GenerateMavenPom::class) {
+        pom.withXml {
+            val root = asElement()
+            val children = root.childNodes
+            val dependenciesNode = children.findFirst("dependencies")
+            dependenciesNode?.apply {
+                childNodes.findAll("dependency").forEach { removeChild(it) }
+            }
         }
     }
 }

--- a/buildSrc/src/main/kotlin/bootstrap-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/bootstrap-plugin.gradle.kts
@@ -1,8 +1,3 @@
-import Bootstrap_plugin_gradle.Nodes.findAll
-import Bootstrap_plugin_gradle.Nodes.findFirst
-import org.w3c.dom.Node
-import org.w3c.dom.NodeList
-
 /*
  * Copyright 2020, TeamDev. All rights reserved.
  *
@@ -22,6 +17,11 @@ import org.w3c.dom.NodeList
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+import Bootstrap_plugin_gradle.Nodes.findAll
+import Bootstrap_plugin_gradle.Nodes.findFirst
+import org.w3c.dom.Node
+import org.w3c.dom.NodeList
 
 plugins {
     java

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -94,10 +94,14 @@ object Versions {
     val javaPoet         = "1.12.1"
     val autoService      = "1.0-rc6"
     val autoCommon       = "0.10"
-    val jackson          = "2.9.10.4"
+    val jackson          = "2.9.10.5"
     val animalSniffer    = "1.18"
     val apiguardian      = "1.1.0"
     val javaxAnnotation  = "1.3.2"
+    val klaxon           = "5.4"
+    val ouathJwt         = "3.10.3"
+    val bouncyCastlePkcs = "1.66"
+    val assertK          = "0.22"
 
     /**
      * Version of the SLF4J library.
@@ -159,13 +163,20 @@ object Build {
 
     object AutoService {
         val annotations = "com.google.auto.service:auto-service-annotations:${Versions.autoService}"
-        val processor = "com.google.auto.service:auto-service:${Versions.autoService}"
+        val processor   = "com.google.auto.service:auto-service:${Versions.autoService}"
     }
 }
 
 object Gen {
     val javaPoet        = "com.squareup:javapoet:${Versions.javaPoet}"
     val javaxAnnotation = "javax.annotation:javax.annotation-api:${Versions.javaxAnnotation}"
+}
+
+object Publishing {
+    val klaxon           = "com.beust:klaxon:${Versions.klaxon}"
+    val oauthJwt         = "com.auth0:java-jwt:${Versions.ouathJwt}"
+    val bouncyCastlePkcs = "org.bouncycastle:bcpkix-jdk15on:${Versions.bouncyCastlePkcs}"
+    val assertK          = "com.willowtreeapps.assertk:assertk-jvm:${Versions.assertK}"
 }
 
 object Grpc {
@@ -275,6 +286,7 @@ object Deps {
     val test = Test
     val versions = Versions
     val scripts = Scripts
+    val publishing = Publishing
 }
 
 object DependencyResolution {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/license-report.md
+++ b/license-report.md
@@ -338,4 +338,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 27 11:28:28 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 27 11:52:59 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.5.24`
+# Dependencies of `io.spine.tools:spine-plugin:1.5.25`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -226,10 +226,10 @@
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.20.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.24.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.20.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.24.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
 1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
@@ -310,10 +310,11 @@
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 7.1
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 7.3.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
-     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
-     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
+     * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** org.pcollections **Name:** pcollections **Version:** 2.1.2
@@ -337,4 +338,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 26 15:53:09 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 27 11:28:28 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -338,4 +338,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 27 11:52:59 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 27 14:22:42 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -226,10 +226,10 @@
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.24.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.20.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.24.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.20.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
 1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
@@ -310,11 +310,10 @@
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 7.3.1
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 7.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
-     * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
-     * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** org.pcollections **Name:** pcollections **Version:** 2.1.2
@@ -338,4 +337,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 24 18:33:54 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 26 15:53:09 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -338,4 +338,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 27 14:22:42 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 27 17:13:18 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -82,8 +82,6 @@ pluginBundle {
         version = pluginVersion
     }
 
-    withDependencies { clear() }
-
     plugins {
         named("spineBootstrapPlugin") {
             version = pluginVersion

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -24,8 +24,8 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     java
-    id("com.gradle.plugin-publish").version("0.11.0")
-    id("com.github.johnrengelman.shadow").version("5.2.0")
+    id("com.gradle.plugin-publish").version("0.12.0")
+    id("com.github.johnrengelman.shadow").version("6.0.0")
     `bootstrap-plugin`
     `func-test-env`
     `prepare-config-resources`

--- a/pom.xml
+++ b/pom.xml
@@ -52,25 +52,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.5.21</version>
+    <version>1.5.27</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.5.21</version>
+    <version>1.5.27</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.5.21</version>
+    <version>1.5.27</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-js-plugin</artifactId>
-    <version>1.5.21</version>
+    <version>1.5.27</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -106,13 +106,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.5.21</version>
+    <version>1.5.27</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.5.21</version>
+    <version>1.5.27</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -152,12 +152,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.5.21</version>
+    <version>1.5.27</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>
     <artifactId>pmd-java</artifactId>
-    <version>6.24.0</version>
+    <version>6.20.0</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.5.24</version>
+<version>1.5.25</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -157,7 +157,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>
     <artifactId>pmd-java</artifactId>
-    <version>6.20.0</version>
+    <version>6.24.0</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,25 +52,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.5.27</version>
+    <version>1.5.28</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.5.27</version>
+    <version>1.5.28</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.5.27</version>
+    <version>1.5.28</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-js-plugin</artifactId>
-    <version>1.5.27</version>
+    <version>1.5.28</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -106,13 +106,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.5.27</version>
+    <version>1.5.28</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.5.27</version>
+    <version>1.5.28</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -152,7 +152,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.5.27</version>
+    <version>1.5.28</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,7 +29,7 @@
  * already in the root directory.
  */
 
-val spineBaseVersion: String by extra("1.5.21")
+val spineBaseVersion: String by extra("1.5.27")
 val spineTimeVersion: String by extra("1.5.21")
 val spineVersion: String by extra("1.5.21")
-val pluginVersion: String by extra("1.5.24")
+val pluginVersion: String by extra("1.5.25")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,7 +29,7 @@
  * already in the root directory.
  */
 
-val spineBaseVersion: String by extra("1.5.27")
+val spineBaseVersion: String by extra("1.5.28")
 val spineTimeVersion: String by extra("1.5.24")
 val spineVersion: String by extra("1.5.26")
 val pluginVersion: String by extra("1.5.25")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -30,6 +30,6 @@
  */
 
 val spineBaseVersion: String by extra("1.5.27")
-val spineTimeVersion: String by extra("1.5.21")
-val spineVersion: String by extra("1.5.21")
+val spineTimeVersion: String by extra("1.5.24")
+val spineVersion: String by extra("1.5.26")
 val pluginVersion: String by extra("1.5.25")


### PR DESCRIPTION
This PR updates the Model Compiler, along with other Spine dependencies, with the purpose of propagating the new way of invoking Spine Protoc plugin to our example repositories.

Also, in this PR we get rid of deprecated API usage.