### PR TITLE
Revert POM processing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+How to contribute
+==================
+Thank you for wanting to contribute to Spine. The following links will help you get started:
+ * [Wiki home][wiki-home] — the home of the framework developer's documentation.
+ * [Getting started with Spine in Java][quick-start] — this guide will walk you through
+   a minimal client-server “Hello World!” application in Java. 
+ * [Introduction][docs-intro] — this section of the Spine Documentation will help you understand
+   the foundation of the framework.
+   
+Pull requests
+-------------
+The work on an improvement starts with creating an issue that describes a bug or a feature. The issue will be used for communications on the proposed improvements. 
+If code changes are going to be introduced, the issue should also have a link to the corresponding Pull Request.
+
+Code contributions should:
+  * Be accompanied by tests.
+  * Be licensed under the Apache v2.0 license with the appropriate copyright header for each file.
+  * Formatted according to the code style. See [Wiki home][wiki-home] for the links to
+    style guides of the programming languages used in the framework.  
+
+Contributor License Agreement
+-----------------------------
+Contributions to the code of Spine Event Engine framework and its libraries must be accompanied by
+Contributor License Agreement (CLA).
+
+ * If you are an individual writing original source code and you're sure you own
+   the intellectual property, then you'll need to sign an individual CLA.
+   
+ * If you work for a company which wants you to contribute your work,
+   then an authorized person from your company will need to sign a corporate CLA.
+
+Please [contact us][legal-email] for arranging the paper formalities.
+   
+[wiki-home]: https://github.com/SpineEventEngine/SpineEventEngine.github.io/wiki
+[quick-start]: https://spine.io/docs/quick-start
+[docs-intro]: https://spine.io/docs/introduction
+[legal-email]: mailto:legal@teamdev.com

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,7 +27,7 @@ repositories {
     jcenter()
 }
 
-val jacksonVersion = "2.11.2"
+val jacksonVersion = "2.11.0"
 
 dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")

--- a/buildSrc/src/main/kotlin/bootstrap-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/bootstrap-plugin.gradle.kts
@@ -18,11 +18,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Bootstrap_plugin_gradle.Nodes.findAll
-import Bootstrap_plugin_gradle.Nodes.findFirst
-import org.w3c.dom.Node
-import org.w3c.dom.NodeList
-
 plugins {
     java
     `java-gradle-plugin`
@@ -35,57 +30,6 @@ gradlePlugin {
             implementationClass = "io.spine.tools.gradle.bootstrap.BootstrapPlugin"
             displayName = "Spine Bootstrap"
             description = "Prepares a Gradle project for development on Spine."
-        }
-    }
-}
-
-/**
- * Utilities for working with DOM nodes.
- */
-object Nodes {
-
-    /**
-     * Finds the first node with the given name in this `NodeList`.
-     *
-     * @return a node with the given name or `null` if this list does not contain such a node
-     */
-    fun NodeList.findFirst(name: String): Node? {
-        for (i in (0 until length)) {
-            val child = item(i)
-            if (child.nodeName == name) {
-                return child
-            }
-        }
-        return null
-    }
-
-    /**
-     * Finds all the nodes with the given name in this `NodeList`.
-     *
-     * @return a list of all the nodes with a given name; an empty list if this `NodeList` does not
-     * contain such nodes
-     */
-    fun NodeList.findAll(name: String): List<Node> {
-        val nodes = mutableListOf<Node>()
-        for (i in (0 until length)) {
-            val child = item(i)
-            if (child.nodeName == name) {
-                nodes.add(child)
-            }
-        }
-        return nodes
-    }
-}
-
-project.afterEvaluate {
-    tasks.withType(GenerateMavenPom::class) {
-        pom.withXml {
-            val root = asElement()
-            val children = root.childNodes
-            val dependenciesNode = children.findFirst("dependencies")
-            dependenciesNode?.apply {
-                childNodes.findAll("dependency").forEach { removeChild(it) }
-            }
         }
     }
 }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.5.25`
+# Dependencies of `io.spine.tools:spine-plugin:1.5.26`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -338,4 +338,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 27 17:13:18 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 28 15:11:12 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -82,6 +82,8 @@ pluginBundle {
         version = pluginVersion
     }
 
+    withDependencies { clear() }
+
     plugins {
         named("spineBootstrapPlugin") {
             version = pluginVersion

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.5.25</version>
+<version>1.5.26</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
 val spineBaseVersion: String by extra("1.5.28")
 val spineTimeVersion: String by extra("1.5.24")
 val spineVersion: String by extra("1.5.26")
-val pluginVersion: String by extra("1.5.25")
+val pluginVersion: String by extra("1.5.26")


### PR DESCRIPTION
In this PR we revert the effort to get rid of deprecated API usage when processing the plugin's POM.

The old way of doing this is through the `withDependencies {}` API, which is deprecated. Recently, we've tried using the API of `maven-publish` plugin instead, just as the warning suggests. However, that change does not seem to work — the plugin was published with dependencies in the POM anyway.

This PR makes the issue #48 relevant again.

This might be related to this [issue](https://github.com/gradle/gradle/issues/10684) in Gradle.