### PR TITLE
Remove debug logging

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.5.26`
+# Dependencies of `io.spine.tools:spine-plugin:1.5.27`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -338,4 +338,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 28 15:11:12 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 28 17:52:22 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.5.26</version>
+<version>1.5.27</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -52,25 +52,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.5.28</version>
+    <version>1.5.29</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.5.28</version>
+    <version>1.5.29</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.5.28</version>
+    <version>1.5.29</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-js-plugin</artifactId>
-    <version>1.5.28</version>
+    <version>1.5.29</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -106,13 +106,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.5.28</version>
+    <version>1.5.29</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.5.28</version>
+    <version>1.5.29</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -152,7 +152,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.5.28</version>
+    <version>1.5.29</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,7 +29,7 @@
  * already in the root directory.
  */
 
-val spineBaseVersion: String by extra("1.5.28")
+val spineBaseVersion: String by extra("1.5.29")
 val spineTimeVersion: String by extra("1.5.24")
 val spineVersion: String by extra("1.5.26")
 val pluginVersion: String by extra("1.5.26")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
 val spineBaseVersion: String by extra("1.5.29")
 val spineTimeVersion: String by extra("1.5.24")
 val spineVersion: String by extra("1.5.26")
-val pluginVersion: String by extra("1.5.26")
+val pluginVersion: String by extra("1.5.27")


### PR DESCRIPTION
Previously, the version of Model Compiler contained unwanted debug logging via `System.out`. In this PR we migrate to the newest version, in which that output is removed.