### PR TITLE
Release `1.6.0`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.5.29`
+# Dependencies of `io.spine.tools:spine-plugin:1.6.0`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -338,4 +338,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 03 17:30:16 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 08 23:08:32 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.5.29</version>
+<version>1.6.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -52,25 +52,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-js-plugin</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -106,13 +106,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -152,7 +152,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,9 +29,9 @@
  * already in the root directory.
  */
 
-val spineBaseVersion: String by extra("1.5.31")
-val spineTimeVersion: String by extra("1.5.24")
-val spineVersion: String by extra("1.5.29")
-val spineWebVersion: String by extra("1.5.25")
-val spineGCloudVersion: String by extra("1.5.22")
-val pluginVersion: String by extra("1.5.29")
+val spineBaseVersion: String by extra("1.6.0")
+val spineTimeVersion: String by extra("1.6.0")
+val spineVersion: String by extra("1.6.0")
+val spineWebVersion: String by extra("1.6.0")
+val spineGCloudVersion: String by extra("1.6.0")
+val pluginVersion: String by extra("1.6.0")


### PR DESCRIPTION
This PR does the release of a `bootstrap` plugin version `1.6.0`.

With this release the `bootstrap` plugin receives support for more automated project configurations [#65].

### Library dependencies

It's now possible to add some of the Spine libraries to project dependencies through the API provided by the plugin. This includes:
 - the Google Cloud Datastore storage implementation:
```groovy
spine.enableJava {
    withDatastore()
}
```
 - web API library:
```groovy
spine.enableJava().webServer()
```
 - web library with integration over the Firebase Realtime Database:
```groovy
spine.enableJava().firebaseWebServer()
```

### IDEA configuration

If both Bootstrap and the `idea` plugin are applied, Bootstrap configures the `idea` plugin, so that the IDE displays sources and generated sources as expected.

## Infrastructure

The project build scripts are migrated to Kotlin [#50]. 
