### PR TITLE
Update plugin version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Gradle plugin for bootstrapping projects built with Spine.
 In order to apply the plugin to a Gradle project, in `build.gralde` add the following config:
 ```gradle
 plugins {
-    id("io.spine.tools.gradle.bootstrap").version("1.5.29")
+    id("io.spine.tools.gradle.bootstrap").version("1.6.0")
 }
 ```
 


### PR DESCRIPTION
This PR updates the version to `1.6.0` in the project README, which wasn't done in #67.

The `1.6.0` is not yet published, as the corresponding build was cancelled, so this can be safely merged.