### PR TITLE
Align Spine libraries

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.6.11`
+# Dependencies of `io.spine.tools:spine-plugin:1.6.12`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -334,4 +334,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Nov 17 19:24:52 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 20 18:59:36 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -25,7 +25,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 plugins {
     java
     id("com.gradle.plugin-publish").version("0.12.0")
-    id("com.github.johnrengelman.shadow").version("6.0.0")
+    id("com.github.johnrengelman.shadow").version("6.1.0")
     `bootstrap-plugin`
     `prepare-config-resources`
 }

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.6.11</version>
+<version>1.6.12</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -52,31 +52,31 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.6.11</version>
+    <version>1.6.12</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.6.11</version>
+    <version>1.6.12</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.6.11</version>
+    <version>1.6.12</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-dart-plugin</artifactId>
-    <version>1.6.11</version>
+    <version>1.6.12</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-js-plugin</artifactId>
-    <version>1.6.11</version>
+    <version>1.6.12</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -112,13 +112,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.6.11</version>
+    <version>1.6.12</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.6.11</version>
+    <version>1.6.12</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,9 +29,9 @@
  * already in the root directory.
  */
 
-val spineBaseVersion: String by extra("1.6.11")
-val spineTimeVersion: String by extra("1.6.0")
-val spineVersion: String by extra("1.6.6")
-val spineWebVersion: String by extra("1.6.6")
-val spineGCloudVersion: String by extra("1.6.6")
-val pluginVersion: String by extra("1.6.11")
+val spineBaseVersion: String by extra("1.6.12")
+val spineTimeVersion: String by extra("1.6.11")
+val spineVersion: String by extra("1.6.13")
+val spineWebVersion: String by extra("1.6.12")
+val spineGCloudVersion: String by extra("1.6.12")
+val pluginVersion: String by extra("1.6.12")


### PR DESCRIPTION
This PR bumps Spine libraries in order to align them with the same core 3rd-party dependencies, e.g. Protobuf, and avoid potential issues with having multiple versions of the same library.