### PR TITLE
Version increment check

### DIFF
--- a/.github/workflows/increment_guard.yml
+++ b/.github/workflows/increment_guard.yml
@@ -1,0 +1,26 @@
+# Ensures that the current lib version is not yet published but executing the Gradle
+# `checkVersionIncrement` task.
+
+name: Check version increment
+
+on:
+  push:
+    branches: '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Pull config
+        run: git submodule update --init --recursive
+
+      - name: Check version is not yet published
+        shell: bash
+        run: ./gradlew checkVersionIncrement

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.6.12`
+# Dependencies of `io.spine.tools:spine-plugin:1.6.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -334,4 +334,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 23 17:35:03 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 23 17:45:12 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -334,4 +334,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 23 17:31:19 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 23 17:35:03 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -334,4 +334,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 20 18:59:36 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 23 17:31:19 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.6.12</version>
+<version>1.6.15</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -52,31 +52,31 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-dart-plugin</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-js-plugin</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -112,13 +112,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,9 +29,9 @@
  * already in the root directory.
  */
 
-val spineBaseVersion: String by extra("1.6.12")
-val spineTimeVersion: String by extra("1.6.11")
-val spineVersion: String by extra("1.6.13")
-val spineWebVersion: String by extra("1.6.12")
-val spineGCloudVersion: String by extra("1.6.12")
-val pluginVersion: String by extra("1.6.12")
+val spineBaseVersion: String by extra("1.6.13")
+val spineTimeVersion: String by extra("1.6.13")
+val spineVersion: String by extra("1.6.15")
+val spineWebVersion: String by extra("1.6.15")
+val spineGCloudVersion: String by extra("1.6.15")
+val pluginVersion: String by extra("1.6.15")


### PR DESCRIPTION
In this PR we add a new GitHub Actions check which invokes the `checkVersionIncrement` Gradle task.

The check fails if the current version of the library is already published in order to avoid overriding existing versions.
The check runs on any `push`, but the task is only enabled for all branches except `master`. On `master`, the check will always pass.