### PR TITLE
Release `1.8.0` — merge to `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In order to apply the plugin to a Gradle project, in `build.gralde` add the foll
 
 ```gradle
 plugins {
-    id("io.spine.tools.gradle.bootstrap").version("1.7.0")
+    id("io.spine.tools.gradle.bootstrap").version("1.8.0")
 }
 ```
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.7.1`
+# Dependencies of `io.spine.tools:spine-plugin:1.8.0`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -335,4 +335,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 11 16:22:17 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 20 16:24:49 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.7.1</version>
+<version>1.8.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -40,31 +40,31 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-dart-plugin</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-js-plugin</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -94,13 +94,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -35,8 +35,8 @@
  * already in the root directory.
  */
 
-val spineVersion: String by extra("1.7.2-SNAPSHOT.0")
-val spineBaseVersion: String by extra("1.7.4")
+val spineVersion: String by extra("1.8.0")
+val spineBaseVersion: String by extra("1.8.0")
 val spineTimeVersion: String by extra(spineVersion)
 val spineWebVersion: String by extra(spineVersion)
 val spineGCloudVersion: String by extra(spineVersion)

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -35,7 +35,7 @@
  * already in the root directory.
  */
 
-val spineVersion: String by extra("1.7.1")
+val spineVersion: String by extra("1.7.2-SNAPSHOT.0")
 val spineBaseVersion: String by extra("1.7.4")
 val spineTimeVersion: String by extra(spineVersion)
 val spineWebVersion: String by extra(spineVersion)


### PR DESCRIPTION
This changeset updates `master` with the release `1.8.0`.

The support of `1.x` branch will be carried out in `1.x-dev` branch. Therefore, it should not be deleted after this PR is merged.