### PR TITLE
Release 1.8.2

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,13 +29,13 @@ jobs:
         shell: bash
         run: sudo apt-get install dart
 
-      - name: Active `protoc-plugin`
+      - name: Activate `protoc-plugin`
         shell: bash
-        run: pub global activate protoc_plugin
+        run: dart pub global activate protoc_plugin
 
-      - name: Active `dart_code_gen`
+      - name: Activate `dart_code_gen`
         shell: bash
-        run: pub global activate dart_code_gen
+        run: dart pub global activate dart_code_gen
 
       - name: Run Gradle build
         shell: bash

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: Tests on Windows
+name: Build under Ubuntu
 
 on:
   pull_request:
@@ -8,8 +8,7 @@ on:
 
 jobs:
   build:
-
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -22,10 +21,11 @@ jobs:
           distribution: zulu
 
       - name: Run tests with Gradle
-        shell: cmd
-        run: >
-          choco install dart-sdk --limitoutput
-          && refreshenv
-          && pub global activate protoc_plugin
-          && pub global activate dart_code_gen
-          && gradlew.bat build
+        shell: bash
+        run: ./config/scripts/update-apt.sh \
+          && sudo apt-get install dart \
+          && pub global activate protoc_plugin \
+          && pub global activate dart_code_gen \
+          && ./gradlew build
+
+

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,7 +22,8 @@ jobs:
 
       - name: Run tests with Gradle
         shell: bash
-        run: ./config/scripts/update-apt.sh \
+        run: chmod +x ./config/scripts/update-apt.sh
+          && ./config/scripts/update-apt.sh \
           && sudo apt-get install dart \
           && pub global activate protoc_plugin \
           && pub global activate dart_code_gen \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,13 +20,26 @@ jobs:
           java-version: 8
           distribution: zulu
 
-      - name: Run tests with Gradle
+      - name: Update APT
         shell: bash
         run: chmod +x ./config/scripts/update-apt.sh
-          && ./config/scripts/update-apt.sh \
-          && sudo apt-get install dart \
-          && pub global activate protoc_plugin \
-          && pub global activate dart_code_gen \
-          && ./gradlew build
+          && ./config/scripts/update-apt.sh
+
+      - name: Install Dart
+        shell: bash
+        run: sudo apt-get install dart
+
+      - name: Active `protoc-plugin`
+        shell: bash
+        run: pub global activate protoc_plugin
+
+      - name: Active `dart_code_gen`
+        shell: bash
+        run: pub global activate dart_code_gen
+
+      - name: Run Gradle build
+        shell: bash
+        run: ./gradlew build
+
 
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -26,6 +26,6 @@ jobs:
         run: >
           choco install dart-sdk --limitoutput
           && refreshenv
-          && pub global activate protoc_plugin
-          && pub global activate dart_code_gen
+          && dart pub global activate protoc_plugin
+          && dart pub global activate dart_code_gen
           && gradlew.bat build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2022, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In order to apply the plugin to a Gradle project, in `build.gralde` add the foll
 
 ```gradle
 plugins {
-    id("io.spine.tools.gradle.bootstrap").version("1.8.0")
+    id("io.spine.tools.gradle.bootstrap").version("1.8.2")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/bootstrap-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/bootstrap-plugin.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/prepare-config-resources.gradle.kts
+++ b/buildSrc/src/main/kotlin/prepare-config-resources.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2022, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:spine-plugin:1.8.0`
+# Dependencies of `io.spine.tools:spine-plugin:1.8.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -335,4 +335,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 20 16:24:49 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jun 27 17:38:50 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/BootstrapPlugin.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/BootstrapPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/CodeGenExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/CodeGenExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/DartExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/DartExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/DartTaskName.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/DartTaskName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/Extension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaCodegenExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaCodegenExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaScriptExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/JavaScriptExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/ModelExtension.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/ModelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/SpineBasedProject.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/SpineBasedProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/SpinePluginScripts.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/SpinePluginScripts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/SpinePluginTarget.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/SpinePluginTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/bootstrap/package-info.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/bootstrap/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/config/ArtifactSnapshot.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/config/ArtifactSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/config/SpineDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/config/package-info.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/config/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/protoc/ProtobufGenerator.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/protoc/ProtobufGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/protoc/ProtocPlugin.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/protoc/ProtocPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/java/io/spine/tools/gradle/protoc/package-info.java
+++ b/plugin/src/main/java/io/spine/tools/gradle/protoc/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/build.gradle.template
+++ b/plugin/src/test/build.gradle.template
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/BootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/BootstrapPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/ExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/SpineBootstrapPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/package-info.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/func/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/given/FakeArtifacts.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/given/FakeArtifacts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/java/io/spine/tools/gradle/bootstrap/given/package-info.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/bootstrap/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/java/io/spine/tools/gradle/protoc/ProtocPluginTest.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/protoc/ProtocPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/java/io/spine/tools/gradle/protoc/given/TestPluginOptionsContainer.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/protoc/given/TestPluginOptionsContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/java/io/spine/tools/gradle/protoc/given/package-info.java
+++ b/plugin/src/test/java/io/spine/tools/gradle/protoc/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/resources/func-test/src/main/proto/client.proto
+++ b/plugin/src/test/resources/func-test/src/main/proto/client.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/resources/func-test/src/main/proto/restaurant.proto
+++ b/plugin/src/test/resources/func-test/src/main/proto/restaurant.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/resources/func-test/src/main/proto/restaurant_rejections.proto
+++ b/plugin/src/test/resources/func-test/src/main/proto/restaurant_rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/resources/func-test/src/main/proto/roller_coaster.proto
+++ b/plugin/src/test/resources/func-test/src/main/proto/roller_coaster.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/test/resources/func-test/src/main/proto/server.proto
+++ b/plugin/src/test/resources/func-test/src/main/proto/server.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-bootstrap</artifactId>
-<version>1.8.0</version>
+<version>1.8.2</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -40,31 +40,31 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-dart-plugin</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-proto-js-plugin</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -94,13 +94,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -35,8 +35,8 @@
  * already in the root directory.
  */
 
-val spineVersion: String by extra("1.8.0")
-val spineBaseVersion: String by extra("1.8.0")
+val spineVersion: String by extra("1.8.2")
+val spineBaseVersion: String by extra("1.8.2")
 val spineTimeVersion: String by extra(spineVersion)
 val spineWebVersion: String by extra(spineVersion)
 val spineGCloudVersion: String by extra(spineVersion)


### PR DESCRIPTION
This is a release of `bootstrap` plugin which simplifies the configuration of Spine framework in version `1.8.2`.

This changeset also updates the year value in the copyright headers.